### PR TITLE
Add aieml data to Vitis package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ link:     ; @echo "📦 Link complete: $(XSA)"
 
 ########################  v++ --package flags ##############################
 PKG_COMMON = --platform $(PLATFORM) --package.out_dir $(PKG_DIR) \
-             --package.defer_aie_run --package.sd_file $(EXEC)
+             --package.defer_aie_run --package.sd_file $(EXEC) \
+             --package.sd_dir aieml/data
 
 ifeq ($(TARGET),sw_emu)
   ifeq ($(EMU_PS),X86)


### PR DESCRIPTION
## Summary
- Include `aieml/data` directory in the SD card packaging flags

## Testing
- `make package TARGET=sw_emu EMU_PS=X86` *(fails: v++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6890d3c696788320bdf7dc54d39664a4