### PR TITLE
docs: add PL kernel build overview

### DIFF
--- a/pl/README.md
+++ b/pl/README.md
@@ -1,0 +1,38 @@
+# PL Kernels
+
+This directory contains several Vitis HLS kernels used to move and process data between DDR memory and the AI Engine graph.
+
+## Available kernels
+- **mm2s_pl** – transfers `float` words from memory to an AXI4-Stream interface using an AXI master port and a simple pipeline loop.
+- **s2mm_pl** – reads data from an AXI4-Stream and writes it back to memory through an AXI master port.
+- **leaky_relu_pl** – applies a leaky ReLU activation to each value on the input stream and forwards the result.
+- **leaky_splitter_pl** – splits a single input stream into multiple cascaded outputs.
+- **roll_concat** – helper kernel that rolls a 128-element vector multiple times and concatenates the shifted versions.
+
+Each kernel has a matching `*_test.cpp` file (for example, `mm2s_test.cpp`) or a dedicated test like `roll_concat_test.cpp` used for functional validation.
+
+## Build scripts
+The top-level [Makefile](Makefile) orchestrates all kernel builds using the accompanying TCL scripts:
+
+- `mm2s_project.tcl`
+- `s2mm_project.tcl`
+- `leaky_relu_project.tcl`
+- `leaky_splitter_project.tcl`
+
+The default target list can be overridden using the `KERNELS` variable. Useful commands:
+
+```bash
+cd pl
+make kernels           # synthesize and export all kernels
+make sim TARGET=csim   # run C simulation for listed kernels
+make sim TARGET=hw_emu # run co-simulation for hardware emulation
+make clean             # remove generated outputs
+```
+
+Synthesis places exported XO/IP files in the `ip/` directory. When preparing a system build, copy or link the required `*.xo` into a build folder such as `build_hw_emu/` referenced by `system_project.yaml`.
+
+## Integration with the system project
+The system project consumes the generated kernels via the `pl_kernels` component defined in [`system_project.yaml`](../system_project.yaml). After building, ensure the expected `.xo` files (e.g. `mm2s_8_128.xo`) reside in `pl/build_<target>/` so the link step can find them.
+
+## Testing
+Run `make sim` or invoke `vitis_hls -f <kernel>_project.tcl csim` to execute the C++ test benches. Tests such as `roll_concat_test.cpp` and the various `*_test.cpp` files verify kernel functionality before synthesis.


### PR DESCRIPTION
## Summary
- document available PL kernels and test benches
- show how Makefile and TCL scripts synthesize and simulate kernels
- describe integration of generated XO files into `system_project.yaml`

## Testing
- `make -C pl sim` *(fails: `vitis_hls` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890dff3bd448320b32051c1668c1ec7