### PR TITLE
Use EMU_PS to select AIE target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ PKG_DIR   := package.$(TARGET)
 XCLBIN    := $(PKG_DIR)/system_$(TARGET).xclbin
 ###########################################################################
 
-# Map top-level TARGET to AIE compiler target
-ifeq ($(TARGET),sw_emu)
+# Map EMU_PS to AIE compiler target
+ifeq ($(EMU_PS),X86)
   AIE_TGT := x86sim
 else
   AIE_TGT := hw
@@ -137,6 +137,7 @@ endif
 print_vars:
 	@echo "TARGET    = $(TARGET)"
 	@echo "EMU_PS    = $(EMU_PS)"
+	@echo "AIE_TGT   = $(AIE_TGT)"
 	@echo "PLATFORM  = $(PLATFORM)"
 	@echo "LINK_CFG  = $(LINK_CFG)"
 	@echo "PACK_CFG  = $(PACK_CFG)"
@@ -164,7 +165,7 @@ clean:
 	rm -rf $(PKG_DIR) build_* *.xclbin *.xsa *.log
 
 clean_all:
-	$(MAKE) -C $(AIE_DIR) clean TARGET=$(TARGET) || true
+	$(MAKE) -C $(AIE_DIR) clean TARGET=$(AIE_TGT) || true
 	$(MAKE) -C pl       clean TARGET=$(TARGET) || true
 	$(MAKE) -C host     clean TARGET=$(TARGET) || true
 	$(MAKE) -C hw_link  clean TARGET=$(TARGET) || true

--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -7,7 +7,7 @@
 PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm
 
 # Target for compilation and simulation. Options: x86sim, hw
-TARGET       = hw
+TARGET       ?= hw
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 DATA_DIR    ?= ../data


### PR DESCRIPTION
## Summary
- Map EMU_PS to the AI Engine target so x86 PS emulation builds the graph for `x86sim` while other PS flows use `hw`.
- Surface the selected `AIE_TGT` in `print_vars` and ensure `clean_all` cleans the correct AIE build directory.
- Allow the AI Engine Makefile to be overridden by the top-level by switching `TARGET` to a conditional assignment.

## Testing
- `make print_vars TARGET=sw_emu EMU_PS=QEMU`
- `make -C aieml -n graph TARGET=x86sim`

------
https://chatgpt.com/codex/tasks/task_e_68922750def0832090cb49ffd86668cc