### PR TITLE
Dump inputs, weights, and intermediate activations for embed block

### DIFF
--- a/model/embed_block.ipynb
+++ b/model/embed_block.ipynb
@@ -100,17 +100,20 @@
     "initializer_map = {init.name: init for init in model.graph.initializer}\n",
     "\n",
     "def tensor_to_numpy(tensor):\n",
-    "    return np.frombuffer(tensor.raw_data,\n",
-    "                         dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type]\n",
-    "                         ).reshape(tensor.dims)\n",
+    "    return np.frombuffer(tensor.raw_data, dtype=onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[tensor.data_type]).reshape(tensor.dims)\n",
     "\n",
     "def dump_tensor(name, arr):\n",
     "    np.savetxt(DUMP_DIR/f'{name}.txt', arr.astype(np.float32).flatten(), fmt='%.6f')\n",
     "\n",
-    "for name, tensor in initializer_map.items():\n",
-    "    arr = tensor_to_numpy(tensor)\n",
-    "    dump_tensor(f'weights_{name}', arr)\n",
-    "    print(f'Dumped {name}  shape={arr.shape}')"
+    "# Iterate over Gemm nodes (dense layers) to dump weights/biases\n",
+    "gemm_nodes = [n for n in model.graph.node if n.op_type == 'Gemm']\n",
+    "for idx, node in enumerate(gemm_nodes, start=1):\n",
+    "    w = tensor_to_numpy(initializer_map[node.input[1]])\n",
+    "    dump_tensor(f'dense{idx}_weight', w)\n",
+    "    if len(node.input) > 2:\n",
+    "        b = tensor_to_numpy(initializer_map[node.input[2]])\n",
+    "        dump_tensor(f'dense{idx}_bias', b)\n",
+    "    print(f'Dumped dense{idx}_weight {w.shape}')"
    ]
   },
   {
@@ -138,8 +141,7 @@
     "        unique_names.append(n)\n",
     "        seen.add(n)\n",
     "input_name = session.get_inputs()[0].name\n",
-    "results = session.run(unique_names, {input_name: x_in})\n",
-    "dense1_out, relu1_out, dense2_out, relu2_out = results\n",
+    "dense1_out, relu1_out, dense2_out, relu2_out, final_out = session.run(unique_names, {input_name: x_in})\n",
     "dump_tensor('dense1_output', dense1_out)\n",
     "dump_tensor('relu1_input', dense1_out)\n",
     "dump_tensor('relu1_output', relu1_out)\n",
@@ -147,7 +149,7 @@
     "dump_tensor('dense2_output', dense2_out)\n",
     "dump_tensor('relu2_input', dense2_out)\n",
     "dump_tensor('relu2_output', relu2_out)\n",
-    "dump_tensor('final_output', relu2_out)\n",
+    "dump_tensor('final_output', final_out)\n",
     "print('Dumped intermediate and final outputs')"
    ]
   },


### PR DESCRIPTION
## Summary
- refactor embed_block notebook to consistently dump dense layer weights/biases
- add dumping of intermediate activations for each layer in inference

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894e398085083208fc8f5a787f4c3df