### PR TITLE
Ensure dump_vals script runs main function

### DIFF
--- a/model/dump_vals.py
+++ b/model/dump_vals.py
@@ -176,3 +176,7 @@ def main() -> None:
     )
 
     print(f"Saved dumps to {out_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add main guard to `dump_vals.py` so it executes when run directly

## Testing
- `python -m py_compile model/dump_vals.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b6dc6edc88320ad57c0df1c6eb86d