### PR TITLE
Add dense layer weight/bias shape validation

### DIFF
--- a/model/dump_vals.py
+++ b/model/dump_vals.py
@@ -84,6 +84,23 @@ def dump_dense_weights(model_path: Path, prefix: str, cascade_len: int, pad_to: 
     if W is None:
         raise RuntimeError(f"No dense weights found in {model_path}")
 
+    # Validate weight and bias shapes to catch unexpected model changes
+    expected_dims = {
+        "dense1": (128, 6),
+        "dense2": (128, 128),
+    }
+    if prefix in expected_dims:
+        exp_out, exp_in = expected_dims[prefix]
+        if W.shape != (exp_out, exp_in):
+            raise ValueError(
+                f"{prefix}: expected weight shape {(exp_out, exp_in)}, got {W.shape}"
+            )
+        if B is None or B.shape[0] != exp_out:
+            raise ValueError(
+                f"{prefix}: expected bias length {exp_out}, "
+                f"got {None if B is None else B.shape[0]}"
+            )
+
     W = W.T  # column-major for AIE
     if pad_to and W.shape[1] < pad_to:
         W = np.pad(W, ((0, 0), (0, pad_to - W.shape[1])), constant_values=0)


### PR DESCRIPTION
## Summary
- validate dense layer weight and bias dimensions against expected shapes
- raise clear errors if shapes mismatch to catch unexpected model changes

## Testing
- `python -m py_compile model/dump_vals.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b7cba32388320a3a4f2dfd1e47753