### PR TITLE
Add bias stream handling to leaky_relu testbench

### DIFF
--- a/pl/src/leaky_relu_test.cpp
+++ b/pl/src/leaky_relu_test.cpp
@@ -12,32 +12,48 @@ typedef hls::axis<data_t, 0, 0, 0> axis_t;
 
 extern "C" {
     void leaky_relu_pl(hls::stream<axis_t>& in_stream,
+                       hls::stream<axis_t>& bias_stream,
                        hls::stream<axis_t>& out_stream);
 }
 
 int main() {
     hls::stream<axis_t> in_stream;
+    hls::stream<axis_t> bias_stream;
     hls::stream<axis_t> out_stream;
 
-    // std::ifstream fin(std::string(DATA_DIR) + "/dense1_output_ref.txt");
-    std::ifstream fin(std::string(DATA_DIR) + "/dense1_output_aie.txt");
-    if (!fin.is_open()) {
-        std::cerr << "ERROR: Cannot open dense1_output.txt" << std::endl;
+    std::ifstream fin_data(std::string(DATA_DIR) + "/dense1_output_aie.txt");
+    if (!fin_data.is_open()) {
+        std::cerr << "ERROR: Cannot open dense1_output_aie.txt" << std::endl;
+        return 1;
+    }
+
+    std::ifstream fin_bias(std::string(DATA_DIR) + "/dense_0_bias.txt");
+    if (!fin_bias.is_open()) {
+        std::cerr << "ERROR: Cannot open dense_0_bias.txt" << std::endl;
         return 1;
     }
 
     for (int i = 0; i < SIZE; ++i) {
         data_t val;
-        fin >> val;
+        fin_data >> val;
         axis_t temp;
         temp.data = val;
         temp.keep = -1;
         temp.last = (i == SIZE - 1);
         in_stream.write(temp);
-    }
-    fin.close();
 
-    leaky_relu_pl(in_stream, out_stream);
+        data_t bias_val;
+        fin_bias >> bias_val;
+        axis_t bias_temp;
+        bias_temp.data = bias_val;
+        bias_temp.keep = -1;
+        bias_temp.last = (i == SIZE - 1);
+        bias_stream.write(bias_temp);
+    }
+    fin_data.close();
+    fin_bias.close();
+
+    leaky_relu_pl(in_stream, bias_stream, out_stream);
 
     std::ofstream fout(std::string(DATA_DIR) + "/leakyrelu_output_pl.txt");
     if (!fout.is_open()) {


### PR DESCRIPTION
## Summary
- extend leaky_relu testbench to stream bias values alongside input data

## Testing
- `g++ -std=c++17 pl/src/leaky_relu_test.cpp pl/src/leaky_relu_pl.cpp -o leaky_relu_test` *(fails: hls_stream.h: No such file or directory)*
- `make sim KERNELS=leaky_relu TARGET=csim` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d24d00e7c83209f0b85602538ba95