### PR TITLE
Connect bias streams in linker configuration

### DIFF
--- a/common/linker.cfg
+++ b/common/linker.cfg
@@ -1,8 +1,8 @@
 [connectivity]
 # Define the number of compute units (CU) for each kernel.
-# This instantiates 4 CUs of mm2s_pl, and 1 for each of the other kernels.
+# This instantiates 6 CUs of mm2s_pl, and 1 for each of the other kernels.
 
-nk=mm2s_pl:4:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1
+nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,mm2s_bias2
 
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
@@ -14,6 +14,8 @@ nk=s2mm_pl:1:s2mm_out
 stream_connect=mm2s_din.s:ai_engine_0.plio_input_dense1
 stream_connect=mm2s_weights1.s:ai_engine_0.plio_weights_dense1
 
+stream_connect=mm2s_bias1.s:relu.bias_stream
+
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
 stream_connect=ai_engine_0.plio_output_dense1:relu.in_stream
 stream_connect=relu.out_stream:splitter.in_stream
@@ -23,6 +25,8 @@ stream_connect=splitter.out_stream_1:ai_engine_0.plio_input_dense2_1
 # Layer 2: Weights streamed from memory into the AIE graph dense128x128
 stream_connect=mm2s_weights2_0.s:ai_engine_0.plio_weights_dense2_0
 stream_connect=mm2s_weights2_1.s:ai_engine_0.plio_weights_dense2_1
+
+stream_connect=mm2s_bias2.s:relu2.bias_stream
 
 # Final output from the AIE graph passes through a second LeakyReLU before being written to memory
 stream_connect=ai_engine_0.plio_output_dense2:relu2.in_stream


### PR DESCRIPTION
## Summary
- add two mm2s compute units for bias streams
- connect bias streams to leaky ReLU kernels in linker configuration

## Testing
- `make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689d453333e48320a03bfa1c7e5d363a