### PR TITLE
Refine intermediate output dumping in run_stage

### DIFF
--- a/model/dump.ipynb
+++ b/model/dump.ipynb
@@ -240,7 +240,8 @@
     "    print(f\"[{tag}] feeding {xin.shape}\")\n",
     "    fetches = names + [sess.get_outputs()[-1].name]\n",
     "    outs = sess.run(fetches, {in_vi.name: xin})\n",
-    "    name_to_arr = dict(zip(fetches, outs))\n",
+    "    name_to_arr = dict(zip(names, outs[:-1]))\n",
+    "    name_to_arr[\"model_output\"] = outs[-1]\n",
     "    # Dumps\n",
     "    out_dir = OUTPUT_ROOT / sanitize(model_path.stem); ensure_dir(out_dir)\n",
     "    dump_txt(out_dir / \"input.txt\", xin, TXT_FLOAT_FMT)\n",
@@ -259,8 +260,8 @@
     "            dump_txt(out_dir / f\"leakyrelu_{r['index']}_output.txt\", arr, TXT_FLOAT_FMT)\n",
     "            with open(out_dir / f\"leakyrelu_{r['index']}_alpha.txt\", \"w\") as f:\n",
     "                f.write(f\"{r['alpha']}\\n\")\n",
-    "    dump_txt(out_dir / \"model_output.txt\", name_to_arr[fetches[-1]], TXT_FLOAT_FMT)\n",
-    "    return name_to_arr[fetches[-1]]\n"
+    "    dump_txt(out_dir / \"model_output.txt\", name_to_arr[\"model_output\"], TXT_FLOAT_FMT)\n",
+    "    return name_to_arr[\"model_output\"]\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Adjust `run_stage` to map intermediate outputs separately and expose final model output under `model_output`
- Reference `model_output` when writing `model_output.txt`

## Testing
- ⚠️ `python - <<'PY'
import json
nb = json.load(open('model/dump.ipynb'))
ns = {}
for cell in nb['cells']:
    if cell.get('cell_type') == 'code':
        code = ''.join(cell['source'])
        exec(code, ns)
PY` *(failed: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689e1bd1a1e083208704948e90ba92f8