### PR TITLE
Rename and update embed macro names

### DIFF
--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -56,19 +56,19 @@ public:
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
         pl_in_dense1  = input_plio::create("plio_input_dense1", plio_32_bits,
-                                          (base_path + "/" + INPUT_DATA_FILE).c_str());
+                                          (base_path + "/" + EMBED_INPUT_DATA).c_str());
         pl_w_dense1   = input_plio::create("plio_weights_dense1", plio_32_bits,
-                                          (base_path + "/" + WEIGHTS_DENSE1_FILE).c_str());
+                                          (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
         pl_out_dense1 = output_plio::create("plio_output_dense1", plio_32_bits,
-                                          (base_path + "/" + OUTPUT_DENSE1_FILE).c_str());
+                                          (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
 
         connect<>(pl_w_dense1.out[0], dense1.inA[0]);
         connect<>(pl_in_dense1.out[0], dense1.inB[0]);
         connect<>(dense1.out[0], pl_out_dense1.in[0]);
 
         for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            std::string in_file = base_path + "/" + LEAKY_RELU_OUTPUT_PREFIX + std::to_string(i) + ".txt";
-            std::string w_file  = base_path + "/" + WEIGHTS_DENSE2_PREFIX + std::to_string(i) + ".txt";
+            std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
+            std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
 
             std::string in_name = "plio_input_dense2_" + std::to_string(i);
             std::string w_name  = "plio_weights_dense2_" + std::to_string(i);
@@ -80,7 +80,7 @@ public:
             connect<>(pl_w_dense2[i].out[0], dense2.inA[i]);
         }
 
-        pl_out_dense2 = output_plio::create("plio_output_dense2", plio_32_bits,(base_path + "/" + OUTPUT_DENSE2_FILE).c_str());
+        pl_out_dense2 = output_plio::create("plio_output_dense2", plio_32_bits,(base_path + "/" + EMBED_DENSE1_OUTPUT).c_str());
         connect<>(dense2.out[0], pl_out_dense2.in[0]);
     }
 };

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -58,9 +58,9 @@ public:
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
         pl_in_dense1  = input_plio::create("plio_input_dense1", plio_16_bits,
-                                          (base_path + "/" + INPUT_DATA_FILE).c_str());
+                                          (base_path + "/" + EMBED_INPUT_DATA).c_str());
         pl_w_dense1   = input_plio::create("plio_weights_dense1", plio_16_bits,
-                                          (base_path + "/" + WEIGHTS_DENSE1_FILE).c_str());
+                                          (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
         pl_out_dense1 = output_plio::create("plio_output_dense1", plio_16_bits,
                                           (base_path + "/dense1_output_aie.txt").c_str());
 
@@ -68,8 +68,8 @@ public:
         connect<>(pl_in_dense1.out[0], dense1.inB[0]);
         connect<>(dense1.out[0], pl_out_dense1.in[0]);
 
-        std::string in_file = base_path + "/" + LEAKY_RELU_OUTPUT_PREFIX + "0.txt";
-        std::string w_file  = base_path + "/" + WEIGHTS_DENSE2_PREFIX + "0.txt";
+        std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + "0.txt";
+        std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt";
 
         pl_in_dense2 = input_plio::create("plio_input_dense2", plio_16_bits, in_file.c_str());
         pl_w_dense2  = input_plio::create("plio_weights_dense2", plio_16_bits, w_file.c_str());

--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -3,16 +3,16 @@
 #define DATA_DIR "/home/synthara/VersalPrjs/LDRD/rtda_demo/data"
 #endif
 
-#define INPUT_DATA_FILE "input.txt"
-#define WEIGHTS_DENSE1_FILE "dense_0_weights.txt"
-#define OUTPUT_DENSE1_FILE "dense_0_output_aie.txt"
+#define EMBED_INPUT_DATA "input.txt"
+#define EMBED_DENSE0_WEIGHTS "dense_0_weights.txt"
+#define EMBED_DENSE0_OUTPUT "dense_0_output_aie.txt"
 
 
-#define LEAKY_RELU_OUTPUT_PREFIX "leakyrelu_0_output_part"
-#define WEIGHTS_DENSE2_PREFIX "dense_1_weights_part"
-#define OUTPUT_DENSE2_FILE "dense_1_output_aie.txt"
+#define EMBED_LEAKYRELU0_OUTPUT_PREFIX "leakyrelu_0_output_part"
+#define EMBED_DENSE1_WEIGHTS_PREFIX "dense_1_weights_part"
+#define EMBED_DENSE1_OUTPUT "dense_1_output_aie.txt"
 
 
-#define BIAS_DENSE1_FILE "dense_0_bias.txt"
-#define BIAS_DENSE2_FILE "dense_1_bias.txt"
-#define HOST_OUTPUT_FILE "host_output.txt"
+#define EMBED_DENSE0_BIAS "dense_0_bias.txt"
+#define EMBED_DENSE1_BIAS "dense_1_bias.txt"
+#define EMBED_HOST_OUTPUT "host_output.txt"

--- a/pl/src/leaky_relu_test.cpp
+++ b/pl/src/leaky_relu_test.cpp
@@ -22,17 +22,17 @@ int main() {
     hls::stream<axis_t> out_stream;
 
     // std::ifstream fin_data(std::string(DATA_DIR) + "/dense_0_output_aie.txt");
-    std::ifstream fin_data(std::string(DATA_DIR) + "/" + std::string(OUTPUT_DENSE2_FILE));
+    std::ifstream fin_data(std::string(DATA_DIR) + "/" + std::string(EMBED_DENSE1_OUTPUT));
 
     if (!fin_data.is_open()) {
-        std::cerr << "ERROR: Cannot open OUTPUT_DENSE2_FILE" << std::endl;
+        std::cerr << "ERROR: Cannot open EMBED_DENSE1_OUTPUT" << std::endl;
         return 1;
     }
 
     // std::ifstream fin_bias(std::string(DATA_DIR) + "/dense_0_bias.txt");
-    std::ifstream fin_bias(std::string(DATA_DIR) + "/"  + std::string(BIAS_DENSE2_FILE));
+    std::ifstream fin_bias(std::string(DATA_DIR) + "/"  + std::string(EMBED_DENSE1_BIAS));
     if (!fin_bias.is_open()) {
-        std::cerr << "ERROR: Cannot open BIAS_DENSE1_FILE" << std::endl;
+        std::cerr << "ERROR: Cannot open EMBED_DENSE1_BIAS" << std::endl;
         return 1;
     }
 

--- a/pl/src/mm2s_test.cpp
+++ b/pl/src/mm2s_test.cpp
@@ -15,7 +15,7 @@ constexpr int SIZE = 8;
 int main() {
     data_t mem[SIZE];
 
-    std::ifstream fin(std::string(DATA_DIR) + "/" + INPUT_DATA_FILE);
+    std::ifstream fin(std::string(DATA_DIR) + "/" + EMBED_INPUT_DATA);
     if (!fin.is_open()) {
         std::cerr << "ERROR: Cannot open input_data.txt" << std::endl;
         return 1;


### PR DESCRIPTION
## Summary
- rename data path macros to `EMBED_*` and update all references
- rename host layer size macros to `EMBED_*`
- adjust graph and PL test code to use new macro names

## Testing
- `make -C host` *(fails: No such file or directory for aarch64-linux-gnu-g++)*
- `g++ -std=c++17 -I./host -I./common -c host/host.cpp` *(fails: experimental/xrt_kernel.h: No such file or directory)*
- `g++ -std=c++17 -I./common -I./pl/src -c pl/src/mm2s_test.cpp` *(fails: ap_int.h: No such file or directory)*
- `g++ -std=c++17 -I./common -I./pl/src -c pl/src/leaky_relu_test.cpp` *(fails: hls_stream.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f6d32df0c83208c0932b702ac8519