### PR TITLE
Define EMBED_HOST_OUTPUT macro for host output path

### DIFF
--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -32,4 +32,4 @@
 #define OUTPUT_DENSE0_OUTPUT "output_dense_0_output_aie.txt"
 
 
-#define HOST_OUTPUT "host_output.txt"
+#define EMBED_HOST_OUTPUT "host_output.txt"

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -49,7 +49,7 @@ int main(int argc, char** argv) {
     std::string weights2_part1File = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "1.txt";
     std::string bias1File          = base_path + "/" + EMBED_DENSE0_BIAS;
     std::string bias2File          = base_path + "/" + EMBED_DENSE1_BIAS;
-    std::string outputFile         = base_path + "/" + EMBED_HOST_OUTPUT;
+    const std::string outputFile   = base_path + "/" + EMBED_HOST_OUTPUT;
 
     try {
         xrt::device device(0);


### PR DESCRIPTION
## Summary
- Replace `HOST_OUTPUT` with `EMBED_HOST_OUTPUT` in shared data paths
- Use new `EMBED_HOST_OUTPUT` macro when constructing the host output file path

## Testing
- `make host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ef089d9c83209e9e7088f468b569