### PR TITLE
Centralize neural network constants in shared header

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ Your project is organized as follows:
 │   ├── Makefile
 │   ├── README.md
 │   ├── graph.cpp
-│   ├── graph.h
-│   └── include.h
+│   └── graph.h
 ├── data/                     # Generated input, weights, and reference output
 ├── pl/                       # Programmable logic (HLS) kernels
 │   ├── Makefile
@@ -126,6 +125,7 @@ Your project is organized as follows:
 │   ├── Makefile
 │   └── README.md
 ├── common/                   # Shared headers and configuration
+│   └── nn_defs.h            # Neural network constants
 ├── model/                    # Python models and utilities
 ├── hls_env.yml               # Conda environment definition
 ├── pack.cfg                  # Packaging configuration

--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h include.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml/README.md
+++ b/aieml/README.md
@@ -11,7 +11,6 @@ implements a minimal multilayer perceptron where activations are handled in the 
 ```
 ├── graph.cpp    # Instantiates `NeuralNetworkGraph` and runs it for simulation
 ├── graph.h      # Graph definition and PLIO connections
-├── include.h    # Common dimension definitions and compile-time constants
 └── Makefile
 ```
 

--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <adf.h>
-#include "include.h"
+#include "../common/nn_defs.h"
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"

--- a/aieml/include.h
+++ b/aieml/include.h
@@ -1,7 +1,0 @@
-
-#pragma once
-
-#define INPUT_SIZE   8
-#define HIDDEN_SIZE  128
-#define OUTPUT_SIZE  128
-#define LEAKY_SLOPE  0.1f

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h include.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -3,7 +3,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
-#include "include.h"
+#include "../common/nn_defs.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;
@@ -43,7 +43,7 @@ static constexpr unsigned int TP_DIM_A_LEADING = 1;
 
 // --- AUTO-CALCULATED CASCADE LENGTHS ---
 static constexpr unsigned int TP_CASC_LEN_768 = aie_params::calculate_casc_len(M, K, sizeof(float));
-// Assumes OUTPUT_SIZE == 128 and HIDDEN_SIZE == 128 are provided by include.h (as in your code)
+// Assumes OUTPUT_SIZE == 128 and HIDDEN_SIZE == 128 are provided by nn_defs.h (as in your code)
 static constexpr unsigned int TP_CASC_LEN_128 = aie_params::calculate_casc_len(OUTPUT_SIZE, HIDDEN_SIZE, sizeof(float));
 
 // Kernels
@@ -130,9 +130,9 @@ public:
 
     // ----------------------------
     // Layer 3: 128x128 (NEW)
-    // Inputs: SUBSOLVER0_LEAKYRELU_1_PREFIX{i}.txt     <-- define in include.h if not present
-    // Weights: SUBSOLVER0_DENSE2_WEIGHTS_PREFIX{i}.txt <-- define in include.h if not present
-    // Output: SUBSOLVER0_DENSE2_OUTPUT                 <-- define in include.h if not present
+    // Inputs: SUBSOLVER0_LEAKYRELU_1_PREFIX{i}.txt     <-- define in nn_defs.h if not present
+    // Weights: SUBSOLVER0_DENSE2_WEIGHTS_PREFIX{i}.txt <-- define in nn_defs.h if not present
+    // Output: SUBSOLVER0_DENSE2_OUTPUT                 <-- define in nn_defs.h if not present
     // ----------------------------
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_1_PREFIX       + std::to_string(i) + ".txt";
@@ -148,9 +148,9 @@ public:
 
     // ----------------------------
     // Layer 4: 128x128 (NEW)
-    // Inputs: SUBSOLVER0_LEAKYRELU_2_PREFIX{i}.txt     <-- define in include.h if not present
-    // Weights: SUBSOLVER0_DENSE3_WEIGHTS_PREFIX{i}.txt <-- define in include.h if not present
-    // Output: SUBSOLVER0_DENSE3_OUTPUT                 <-- define in include.h if not present
+    // Inputs: SUBSOLVER0_LEAKYRELU_2_PREFIX{i}.txt     <-- define in nn_defs.h if not present
+    // Weights: SUBSOLVER0_DENSE3_WEIGHTS_PREFIX{i}.txt <-- define in nn_defs.h if not present
+    // Output: SUBSOLVER0_DENSE3_OUTPUT                 <-- define in nn_defs.h if not present
     // ----------------------------
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_2_PREFIX       + std::to_string(i) + ".txt";

--- a/aieml2/include.h
+++ b/aieml2/include.h
@@ -1,7 +1,0 @@
-
-#pragma once
-
-#define HIDDEN_SIZE  128
-#define OUTPUT_SIZE  128
-#define LEAKY_SLOPE  0.1f
-

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h include.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -3,6 +3,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
+#include "../common/nn_defs.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;

--- a/aieml3/include.h
+++ b/aieml3/include.h
@@ -1,7 +1,0 @@
-
-// #pragma once
-
-// #define HIDDEN_SIZE  128
-// #define OUTPUT_SIZE  128
-// #define LEAKY_SLOPE  0.1f
-

--- a/common/nn_defs.h
+++ b/common/nn_defs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+constexpr int INPUT_SIZE = 8;
+constexpr int HIDDEN_SIZE = 128;
+constexpr int OUTPUT_SIZE = 128;
+constexpr float LEAKY_SLOPE = 0.1f;
+constexpr int CASCADE_LENGTH = 2;
+
+constexpr int EMBED_DENSE0_INPUT_SIZE = INPUT_SIZE;
+constexpr int EMBED_DENSE0_WEIGHTS_SIZE = HIDDEN_SIZE * INPUT_SIZE;
+constexpr int EMBED_DENSE0_BIAS_SIZE = HIDDEN_SIZE;
+constexpr int EMBED_DENSE1_WEIGHTS_PART_SIZE = OUTPUT_SIZE * HIDDEN_SIZE / CASCADE_LENGTH;
+constexpr int EMBED_DENSE1_BIAS_SIZE = OUTPUT_SIZE;
+constexpr int EMBED_FINAL_OUTPUT_SIZE = OUTPUT_SIZE;

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -6,13 +6,7 @@
 #include "experimental/xrt_device.h"
 #include "experimental/xrt_bo.h"
 #include "data_paths.h"
-
-#define EMBED_DENSE0_INPUT_SIZE      8
-#define EMBED_DENSE0_WEIGHTS_SIZE    (128 * 8)
-#define EMBED_DENSE0_BIAS_SIZE       128
-#define EMBED_DENSE1_WEIGHTS_PART_SIZE (128 * 128 / 2)
-#define EMBED_DENSE1_BIAS_SIZE       128
-#define EMBED_FINAL_OUTPUT_SIZE      128
+#include "nn_defs.h"
 
 // Load text files containing floats into a vector
 static std::vector<float> read_file_to_vector(const std::string& filename, int size) {

--- a/pl/src/leaky_relu_pl.cpp
+++ b/pl/src/leaky_relu_pl.cpp
@@ -1,15 +1,13 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include <ap_int.h>
-
-#define SIZE 128
-#define LEAKY_SLOPE (0.1f)
+#include "../../common/nn_defs.h"
 
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
 
 extern "C" {
-    // Apply bias then leaky ReLU to SIZE elements
+    // Apply bias then leaky ReLU to HIDDEN_SIZE elements
     void leaky_relu_pl(hls::stream<axis_t>& in_stream,
                        hls::stream<axis_t>& bias_stream,
                        hls::stream<axis_t>& out_stream) {
@@ -18,7 +16,7 @@ extern "C" {
         #pragma HLS interface axis port=out_stream bundle=gmem depth=128
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-        for (int i = 0; i < SIZE; i++) {
+        for (int i = 0; i < HIDDEN_SIZE; i++) {
             #pragma HLS pipeline II=1
             axis_t val       = in_stream.read();
             axis_t bias_val  = bias_stream.read();

--- a/pl/src/leaky_relu_test.cpp
+++ b/pl/src/leaky_relu_test.cpp
@@ -1,11 +1,10 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include "../../common/data_paths.h"
+#include "../../common/nn_defs.h"
 #include <ap_int.h>
 #include <fstream>
 #include <iostream>
-
-#define SIZE 128
 
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
@@ -36,13 +35,13 @@ int main() {
         return 1;
     }
 
-    for (int i = 0; i < SIZE; ++i) {
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
         data_t val;
         fin_data >> val;
         axis_t temp;
         temp.data = val;
         temp.keep = -1;
-        temp.last = (i == SIZE - 1);
+        temp.last = (i == HIDDEN_SIZE - 1);
         in_stream.write(temp);
 
         data_t bias_val;
@@ -50,7 +49,7 @@ int main() {
         axis_t bias_temp;
         bias_temp.data = bias_val;
         bias_temp.keep = -1;
-        bias_temp.last = (i == SIZE - 1);
+        bias_temp.last = (i == HIDDEN_SIZE - 1);
         bias_stream.write(bias_temp);
     }
     fin_data.close();
@@ -64,7 +63,7 @@ int main() {
         return 1;
     }
 
-    for (int i = 0; i < SIZE; ++i) {
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
         axis_t temp = out_stream.read();
         fout << temp.data << std::endl;
     }

--- a/pl/src/leaky_splitter_pl.cpp
+++ b/pl/src/leaky_splitter_pl.cpp
@@ -1,9 +1,7 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include <ap_int.h>
-
-#define SIZE 128
-#define CASCADE_LENGTH 2
+#include "../../common/nn_defs.h"
 
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
@@ -16,9 +14,9 @@ extern "C" {
         #pragma HLS interface axis port=out_stream
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-        const int SPLIT_SIZE = SIZE / CASCADE_LENGTH;
+        const int SPLIT_SIZE = HIDDEN_SIZE / CASCADE_LENGTH;
 
-        for (int i = 0; i < SIZE; i++) {
+        for (int i = 0; i < HIDDEN_SIZE; i++) {
             #pragma HLS pipeline II=1
             axis_t val = in_stream.read();
             int out_idx = i / SPLIT_SIZE;

--- a/pl/src/leaky_splitter_test.cpp
+++ b/pl/src/leaky_splitter_test.cpp
@@ -1,12 +1,10 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include "../../common/data_paths.h"
+#include "../../common/nn_defs.h"
 #include <ap_int.h>
 #include <fstream>
 #include <iostream>
-
-#define SIZE 128
-#define CASCADE_LENGTH 2
 
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
@@ -26,13 +24,13 @@ int main() {
         return 1;
     }
 
-    for (int i = 0; i < SIZE; ++i) {
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
         data_t val;
         fin >> val;
         axis_t temp;
         temp.data = val;
         temp.keep = -1;
-        temp.last = (i == SIZE - 1);
+        temp.last = (i == HIDDEN_SIZE - 1);
         in_stream.write(temp);
     }
     fin.close();
@@ -50,7 +48,7 @@ int main() {
         }
     }
 
-    const int SPLIT_SIZE = SIZE / CASCADE_LENGTH;
+    const int SPLIT_SIZE = HIDDEN_SIZE / CASCADE_LENGTH;
     for (int i = 0; i < CASCADE_LENGTH; ++i) {
         for (int j = 0; j < SPLIT_SIZE; ++j) {
             axis_t temp = out_stream[i].read();


### PR DESCRIPTION
## Summary
- Consolidated neural network dimensions and parameters into `common/nn_defs.h`
- Switched host, AIE graphs, PL kernels, and testbenches to include the shared header
- Removed redundant `include.h` files and updated Makefiles accordingly

## Testing
- `make aieml TARGET=hw` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a4f1ab85808320beecbd25ab3f98e5