### PR TITLE
chore: unify aie stream naming

### DIFF
--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -63,25 +63,25 @@ using dense128x128 = matrix_vector_mul_graph<
 // =============================================================================
 class NeuralNetworkGraph : public graph {
 public:
-  // Layer 1: 768x128
-  input_plio  pl_in_768[TP_CASC_LEN_768];
-  input_plio  pl_w_768[TP_CASC_LEN_768];
-  output_plio pl_out_768;
+  // Layer 0: 768x128
+  input_plio  layer0_in[TP_CASC_LEN_768];
+  input_plio  layer0_weights[TP_CASC_LEN_768];
+  output_plio layer0_out;
 
-  // Layer 2: 128x128
-  input_plio  pl_in_128_L2[TP_CASC_LEN_128];
-  input_plio  pl_w_128_L2[TP_CASC_LEN_128];
-  output_plio pl_out_128_L2;
+  // Layer 1: 128x128
+  input_plio  layer1_in[TP_CASC_LEN_128];
+  input_plio  layer1_weights[TP_CASC_LEN_128];
+  output_plio layer1_out;
+
+  // Layer 2: 128x128 (NEW)
+  input_plio  layer2_in[TP_CASC_LEN_128];
+  input_plio  layer2_weights[TP_CASC_LEN_128];
+  output_plio layer2_out;
 
   // Layer 3: 128x128 (NEW)
-  input_plio  pl_in_128_L3[TP_CASC_LEN_128];
-  input_plio  pl_w_128_L3[TP_CASC_LEN_128];
-  output_plio pl_out_128_L3;
-
-  // Layer 4: 128x128 (NEW)
-  input_plio  pl_in_128_L4[TP_CASC_LEN_128];
-  input_plio  pl_w_128_L4[TP_CASC_LEN_128];
-  output_plio pl_out_128_L4;
+  input_plio  layer3_in[TP_CASC_LEN_128];
+  input_plio  layer3_weights[TP_CASC_LEN_128];
+  output_plio layer3_out;
 
   // Kernels
   dense768x128 dense768;
@@ -93,7 +93,7 @@ public:
     std::string base_path = DATA_DIR;
 
     // ----------------------------
-    // Layer 1: 768x128
+    // Layer 0: 768x128
     // Inputs: SUBSOLVER0_INPUT_DATA_PREFIX{i}.txt
     // Weights: SUBSOLVER0_DENSE0_WEIGHTS_PREFIX{i}.txt
     // Output: SUBSOLVER0_DENSE0_OUTPUT
@@ -101,17 +101,17 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_768; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX        + std::to_string(i) + ".txt";
       std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      pl_in_768[i] = input_plio::create( ("plio_in_768_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
-      pl_w_768[i]  = input_plio::create( ("plio_w_768_"  + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
-      connect<>(pl_in_768[i].out[0], dense768.inB[i]);
-      connect<>(pl_w_768[i].out[0],  dense768.inA[i]);
+      layer0_in[i]      = input_plio::create( ("layer0_in_"      + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
+      layer0_weights[i] = input_plio::create( ("layer0_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
+      connect<>(layer0_in[i].out[0], dense768.inB[i]);
+      connect<>(layer0_weights[i].out[0],  dense768.inA[i]);
     }
-    pl_out_768 = output_plio::create("plio_out_768", plio_32_bits,
+    layer0_out = output_plio::create("layer0_out", plio_32_bits,
                                      (base_path + "/" + SUBSOLVER0_DENSE0_OUTPUT).c_str());
-    connect<>(dense768.out[0], pl_out_768.in[0]);
+    connect<>(dense768.out[0], layer0_out.in[0]);
 
     // ----------------------------
-    // Layer 2: 128x128
+    // Layer 1: 128x128
     // Inputs: SUBSOLVER0_LEAKYRELU_0_PREFIX{i}.txt
     // Weights: SUBSOLVER0_DENSE1_WEIGHTS_PREFIX{i}.txt
     // Output: SUBSOLVER0_DENSE1_OUTPUT
@@ -119,17 +119,17 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_0_PREFIX       + std::to_string(i) + ".txt";
       std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      pl_in_128_L2[i] = input_plio::create( ("plio_in_128_L2_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
-      pl_w_128_L2[i]  = input_plio::create( ("plio_w_128_L2_"  + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
-      connect<>(pl_in_128_L2[i].out[0], dense128_L2.inB[i]);
-      connect<>(pl_w_128_L2[i].out[0],  dense128_L2.inA[i]);
+      layer1_in[i]      = input_plio::create( ("layer1_in_"      + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
+      layer1_weights[i] = input_plio::create( ("layer1_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
+      connect<>(layer1_in[i].out[0], dense128_L2.inB[i]);
+      connect<>(layer1_weights[i].out[0],  dense128_L2.inA[i]);
     }
-    pl_out_128_L2 = output_plio::create("plio_out_128_L2", plio_32_bits,
-                                        (base_path + "/" + SUBSOLVER0_DENSE1_OUTPUT).c_str());
-    connect<>(dense128_L2.out[0], pl_out_128_L2.in[0]);
+    layer1_out = output_plio::create("layer1_out", plio_32_bits,
+                                     (base_path + "/" + SUBSOLVER0_DENSE1_OUTPUT).c_str());
+    connect<>(dense128_L2.out[0], layer1_out.in[0]);
 
     // ----------------------------
-    // Layer 3: 128x128 (NEW)
+    // Layer 2: 128x128 (NEW)
     // Inputs: SUBSOLVER0_LEAKYRELU_1_PREFIX{i}.txt     <-- define in nn_defs.h if not present
     // Weights: SUBSOLVER0_DENSE2_WEIGHTS_PREFIX{i}.txt <-- define in nn_defs.h if not present
     // Output: SUBSOLVER0_DENSE2_OUTPUT                 <-- define in nn_defs.h if not present
@@ -137,17 +137,17 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_1_PREFIX       + std::to_string(i) + ".txt";
       std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      pl_in_128_L3[i] = input_plio::create( ("plio_in_128_L3_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
-      pl_w_128_L3[i]  = input_plio::create( ("plio_w_128_L3_"  + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
-      connect<>(pl_in_128_L3[i].out[0], dense128_L3.inB[i]);
-      connect<>(pl_w_128_L3[i].out[0],  dense128_L3.inA[i]);
+      layer2_in[i]      = input_plio::create( ("layer2_in_"      + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
+      layer2_weights[i] = input_plio::create( ("layer2_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
+      connect<>(layer2_in[i].out[0], dense128_L3.inB[i]);
+      connect<>(layer2_weights[i].out[0],  dense128_L3.inA[i]);
     }
-    pl_out_128_L3 = output_plio::create("plio_out_128_L3", plio_32_bits,
-                                        (base_path + "/" + SUBSOLVER0_DENSE2_OUTPUT).c_str());
-    connect<>(dense128_L3.out[0], pl_out_128_L3.in[0]);
+    layer2_out = output_plio::create("layer2_out", plio_32_bits,
+                                     (base_path + "/" + SUBSOLVER0_DENSE2_OUTPUT).c_str());
+    connect<>(dense128_L3.out[0], layer2_out.in[0]);
 
     // ----------------------------
-    // Layer 4: 128x128 (NEW)
+    // Layer 3: 128x128 (NEW)
     // Inputs: SUBSOLVER0_LEAKYRELU_2_PREFIX{i}.txt     <-- define in nn_defs.h if not present
     // Weights: SUBSOLVER0_DENSE3_WEIGHTS_PREFIX{i}.txt <-- define in nn_defs.h if not present
     // Output: SUBSOLVER0_DENSE3_OUTPUT                 <-- define in nn_defs.h if not present
@@ -155,13 +155,13 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_2_PREFIX       + std::to_string(i) + ".txt";
       std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      pl_in_128_L4[i] = input_plio::create( ("plio_in_128_L4_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
-      pl_w_128_L4[i]  = input_plio::create( ("plio_w_128_L4_"  + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
-      connect<>(pl_in_128_L4[i].out[0], dense128_L4.inB[i]);
-      connect<>(pl_w_128_L4[i].out[0],  dense128_L4.inA[i]);
+      layer3_in[i]      = input_plio::create( ("layer3_in_"      + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
+      layer3_weights[i] = input_plio::create( ("layer3_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str() );
+      connect<>(layer3_in[i].out[0], dense128_L4.inB[i]);
+      connect<>(layer3_weights[i].out[0],  dense128_L4.inA[i]);
     }
-    pl_out_128_L4 = output_plio::create("plio_out_128_L4", plio_32_bits,
-                                        (base_path + "/" + SUBSOLVER0_DENSE3_OUTPUT).c_str());
-    connect<>(dense128_L4.out[0], pl_out_128_L4.in[0]);
+    layer3_out = output_plio::create("layer3_out", plio_32_bits,
+                                     (base_path + "/" + SUBSOLVER0_DENSE3_OUTPUT).c_str());
+    connect<>(dense128_L4.out[0], layer3_out.in[0]);
   }
 };

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -32,20 +32,20 @@ using dense128x27_padded32 = matrix_vector_mul_graph<
 
 class NeuralNetworkGraph : public graph {
 public:
-    input_plio  pl_in_dense1;
-    input_plio  pl_w_dense1;
-    output_plio pl_out_dense1;
+    input_plio  layer0_in;
+    input_plio  layer0_weights;
+    output_plio layer0_out;
 
     dense128x27_padded32 dense1;
 
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
-        pl_in_dense1  = input_plio::create("plio_input_dense1",  plio_32_bits, (base_path + "/" + OUTPUT_INPUT_DATA).c_str());
-        pl_w_dense1   = input_plio::create("plio_weights_dense1", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_WEIGHTS).c_str());
-        pl_out_dense1 = output_plio::create("plio_output_dense1", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_OUTPUT).c_str());
+        layer0_in      = input_plio::create("layer0_in",  plio_32_bits, (base_path + "/" + OUTPUT_INPUT_DATA).c_str());
+        layer0_weights = input_plio::create("layer0_weights", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_WEIGHTS).c_str());
+        layer0_out     = output_plio::create("layer0_out", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_OUTPUT).c_str());
 
-        connect<>(pl_w_dense1.out[0], dense1.inA[0]);
-        connect<>(pl_in_dense1.out[0], dense1.inB[0]);
-        connect<>(dense1.out[0], pl_out_dense1.in[0]);
+        connect<>(layer0_weights.out[0], dense1.inA[0]);
+        connect<>(layer0_in.out[0], dense1.inB[0]);
+        connect<>(dense1.out[0], layer0_out.in[0]);
     }
 };

--- a/common/linker.cfg
+++ b/common/linker.cfg
@@ -10,26 +10,26 @@ nk=s2mm_pl:1:s2mm_out
 
 # --- Stream Connections ---
 
-# Layer 1: Data and weights streamed from memory into the AIE graph for dense8x128
-stream_connect=mm2s_din.s:ai_engine_0.plio_input_dense1
-stream_connect=mm2s_weights1.s:ai_engine_0.plio_weights_dense1
+# Layer 0: Data and weights streamed from memory into the AIE graph for dense8x128
+stream_connect=mm2s_din.s:ai_engine_0.layer0_in
+stream_connect=mm2s_weights1.s:ai_engine_0.layer0_weights
 
 stream_connect=mm2s_bias1.s:relu.bias_stream
 
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
-stream_connect=ai_engine_0.plio_output_dense1:relu.in_stream
+stream_connect=ai_engine_0.layer0_out:relu.in_stream
 stream_connect=relu.out_stream:splitter.in_stream
-stream_connect=splitter.out_stream_0:ai_engine_0.plio_input_dense2_0
-stream_connect=splitter.out_stream_1:ai_engine_0.plio_input_dense2_1
+stream_connect=splitter.out_stream_0:ai_engine_0.layer1_in_0
+stream_connect=splitter.out_stream_1:ai_engine_0.layer1_in_1
 
-# Layer 2: Weights streamed from memory into the AIE graph dense128x128
-stream_connect=mm2s_weights2_0.s:ai_engine_0.plio_weights_dense2_0
-stream_connect=mm2s_weights2_1.s:ai_engine_0.plio_weights_dense2_1
+# Layer 1: Weights streamed from memory into the AIE graph dense128x128
+stream_connect=mm2s_weights2_0.s:ai_engine_0.layer1_weights_0
+stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
 
 stream_connect=mm2s_bias2.s:relu2.bias_stream
 
 # Final output from the AIE graph passes through a second LeakyReLU before being written to memory
-stream_connect=ai_engine_0.plio_output_dense2:relu2.in_stream
+stream_connect=ai_engine_0.layer1_out:relu2.in_stream
 stream_connect=relu2.out_stream:s2mm_out.s
 
 


### PR DESCRIPTION
## Summary
- standardize AIE stream names to `layerN_in/weights/out`
- adjust linker connections to match new naming

## Testing
- `make aieml` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a5005d14bc8320a444f2926408e9dd