### PR TITLE
docs: document graph variants and data path workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,23 @@ This project demonstrates a custom low-latency neural network pipeline implement
 
 The design partitions work across three components of the Versal architecture:
 
-- **AI Engine-ML** – executes dense layers.
-- **Programmable Logic (PL)** – supplies data-mover kernels and two leaky ReLU units.
+- **AI Engine‑ML graphs** – execute dense layers. The project now contains three
+  variants:
+  - `aieml/` – embedding graph (`dense1 → dense2`).
+  - `aieml2/` – sub‑solver graph with four consecutive dense layers.
+  - `aieml3/` – output head projecting to 27 classes (padded to 32).
+- **Programmable Logic (PL)** – supplies data‑mover kernels and two leaky ReLU units.
 - **Host application** – runs on the processing system and orchestrates data movement and graph execution through XRT.
 
-Each component has its own build instructions in the following READMEs:
+All build instructions are split into component READMEs:
 
-- [AI Engine-ML](aieml/README.md)
+- [AI Engine‑ML graphs](aieml/README.md) (see also [`aieml2`](aieml2/README.md) and [`aieml3`](aieml3/README.md))
 - [Programmable Logic](pl/README.md)
 - [Host Application](host/README.md)
+
+Recent refactoring introduced a shared `common/data_paths.h` header and a `DATA_DIR`
+environment variable so the host, PL tests, and AIE graphs can locate generated text
+files consistently across components.
 
 ---
 

--- a/aieml/README.md
+++ b/aieml/README.md
@@ -1,10 +1,13 @@
 # AI Engine-ML Graph: `dense1 → dense2`
 
-This directory contains the AI Engine-ML (AIE-ML) graph used by the project. The graph
-implements a minimal multilayer perceptron where activations are handled in the programmable logic:
+This directory hosts the **embedding** graph of the project. It implements the first
+two dense layers of the network while leaky ReLU activations run in the
+programmable logic. Later stages are implemented in
+[`aieml2/`](../aieml2/README.md) and [`aieml3/`](../aieml3/README.md).
 
 1. **`dense1`** – matrix-vector multiply producing the hidden activations.
-2. **`dense2`** – second matrix-vector multiply generating the final output.
+2. **`dense2`** – second matrix-vector multiply generating the final output that feeds
+   the PL leaky ReLU.
 
 ## Directory Layout
 

--- a/aieml2/README.md
+++ b/aieml2/README.md
@@ -1,0 +1,36 @@
+# AI Engine-ML Graph: `768×128 → 128×128 → 128×128 → 128×128`
+
+This directory contains the **sub‑solver** graph.  It chains one
+`768×128` matrix‑vector multiply with three `128×128` layers.  Each layer
+consumes inputs and weights from text files defined in
+[`common/data_paths.h`](../common/data_paths.h), allowing the location of
+those files to be overridden with the `DATA_DIR` environment variable.
+
+## Directory Layout
+
+```
+├── graph.cpp    # Instantiates `NeuralNetworkGraph` and runs it for simulation
+├── graph.h      # Graph definition and PLIO connections
+└── Makefile
+```
+
+## Build
+
+From the repository root, compile the graph:
+
+```bash
+cd aieml2
+make graph TARGET=hw       # or TARGET=x86sim
+```
+
+## Simulation
+
+After a successful build, run cycle‑approximate simulation:
+
+```bash
+make sim TARGET=hw        # uses `aiesimulator`
+```
+
+Simulation reads all inputs from `DATA_DIR` and writes layer outputs back to
+the same location.
+

--- a/aieml3/README.md
+++ b/aieml3/README.md
@@ -1,0 +1,35 @@
+# AI Engine-ML Graph: `128×27` Output Head
+
+`aieml3/` implements the final projection layer of the network.  A single
+`128×27` matrix‑vector multiply is padded to a `128×32` implementation to
+match the AIE vector width.  File names for inputs and outputs are provided
+by [`common/data_paths.h`](../common/data_paths.h), and the base directory
+can be changed by setting `DATA_DIR`.
+
+## Directory Layout
+
+```
+├── graph.cpp    # Instantiates `NeuralNetworkGraph` and runs it for simulation
+├── graph.h      # Graph definition and PLIO connections
+└── Makefile
+```
+
+## Build
+
+From the repository root:
+
+```bash
+cd aieml3
+make graph TARGET=hw       # or TARGET=x86sim
+```
+
+## Simulation
+
+Run cycle‑approximate simulation once the build completes:
+
+```bash
+make sim TARGET=hw        # uses `aiesimulator`
+```
+
+Results are written next to the input files under `DATA_DIR`.
+

--- a/host/README.md
+++ b/host/README.md
@@ -8,6 +8,11 @@
 - Cross-compilation sysroot for PetaLinux (default: `/opt/petalinux/2024.2/sysroots/cortexa72-cortexa53-xilinx-linux`)
 - Data files: `input_data.txt`, `weights_dense1.txt`, `weights_dense2_part0.txt`, `weights_dense2_part1.txt`
 
+File names for inputs, weights, and outputs are centralized in
+[`common/data_paths.h`](../common/data_paths.h).  Set the `DATA_DIR`
+environment variable to point the host application to the directory
+containing these files (defaults to `./data`).
+
 ## Build
 The provided `Makefile` cross-compiles the host application for AArch64.
 

--- a/pl/README.md
+++ b/pl/README.md
@@ -10,6 +10,10 @@ This directory contains several Vitis HLS kernels used to move and process data 
 
 Each kernel has a matching `*_test.cpp` file (for example, `mm2s_test.cpp`) used for functional validation.
 
+Test benches reference file names from [`common/data_paths.h`](../common/data_paths.h)
+and honour the `DATA_DIR` environment variable, which lets you relocate the
+text files used during simulation.
+
 ## Build scripts
 The top-level [Makefile](Makefile) orchestrates all kernel builds using the accompanying TCL scripts:
 


### PR DESCRIPTION
## Summary
- outline aieml, aieml2, and aieml3 graph variants in the top-level docs
- add build & sim instructions for new aieml2 and aieml3 directories
- note shared `DATA_DIR` macro in host and PL workflows

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make -C pl kernels` *(fails: vitis_hls: not found)*
- `make -C aieml graph` *(fails: DSPLIB_PATH directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a501b6b0248320b163d572557d463a