### PR TITLE
Align aieml3 graph input dimension with shared constants

### DIFF
--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -20,7 +20,7 @@ constexpr unsigned roundup(unsigned v, unsigned m) { return ((v + m - 1) / m) * 
 static constexpr unsigned VEC_FLOAT = (256 / 8) / sizeof(float); // = 8
 static constexpr unsigned OUT_REAL  = 27;                         // what you want
 static constexpr unsigned OUT_PAD   = roundup(OUT_REAL, VEC_FLOAT); // = 32
-static constexpr unsigned IN_DIM    = 128;
+static constexpr unsigned IN_DIM    = HIDDEN_SIZE;
 
 using dense128x27_padded32 = matrix_vector_mul_graph<
     float, float,


### PR DESCRIPTION
## Summary
- reuse `HIDDEN_SIZE` from `common/nn_defs.h` in aieml3 graph to match shared dimension macros

## Testing
- `make -C aieml3 graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68a5032a1fd483209566835b26f3aa9e