### PR TITLE
Export DATA_DIR for AIE simulations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ EMU_PS    ?= QEMU
 PLATFORM  ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm
 PACK_CFG  := ./pack.cfg
 LINK_CFG  := ./common/linker.cfg
-DATA_DIR  ?= ./data
+DATA_DIR  ?= $(abspath ./data)
 HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
 POST_BOOT := post_boot.sh
 ###########################################################################
@@ -58,10 +58,10 @@ host:
 	$(MAKE) -C host $(SUBOPTS)
 
 $(AIE_LIB):
-	$(MAKE) -C $(AIE_DIR) TARGET=$(AIE_TGT) PLATFORM=$(PLATFORM) DATA_DIR=../$(DATA_DIR)
+	$(MAKE) -C $(AIE_DIR) TARGET=$(AIE_TGT) PLATFORM=$(PLATFORM) DATA_DIR=$(DATA_DIR)
 
 $(PL_XOS):
-	$(MAKE) -C pl TARGET=$(TARGET) DATA_DIR=../$(DATA_DIR) KERNELS="$(HLS_KERNELS)"
+	$(MAKE) -C pl TARGET=$(TARGET) DATA_DIR=$(DATA_DIR) KERNELS="$(HLS_KERNELS)"
 
 ########################  v++ --package flags ##############################
 PKG_COMMON = --platform $(PLATFORM) --package.out_dir $(PKG_DIR) \

--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -91,7 +91,7 @@ ifeq ($(TARGET),x86sim)
 	@echo "COMPLETE: x86sim simulation finished."
 else
 	@echo "--- Starting Hardware Simulation (aiesimulator) ---"
-	$(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
+	DATA_DIR=$(DATA_DIR) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
 	@echo "COMPLETE: Hardware simulation finished."
 endif
 

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -91,7 +91,7 @@ ifeq ($(TARGET),x86sim)
 	@echo "COMPLETE: x86sim simulation finished."
 else
 	@echo "--- Starting Hardware Simulation (aiesimulator) ---"
-	$(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
+	DATA_DIR=$(DATA_DIR) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
 	@echo "COMPLETE: Hardware simulation finished."
 endif
 

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -91,7 +91,7 @@ ifeq ($(TARGET),x86sim)
 	@echo "COMPLETE: x86sim simulation finished."
 else
 	@echo "--- Starting Hardware Simulation (aiesimulator) ---"
-	$(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
+	DATA_DIR=$(DATA_DIR) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
 	@echo "COMPLETE: Hardware simulation finished."
 endif
 


### PR DESCRIPTION
## Summary
- ensure `aiesimulator` inherits `DATA_DIR` in all AIE Makefiles
- make `DATA_DIR` an absolute path and remove relative passes in sub-makes

## Testing
- `make print_vars`
- `make -n -C aieml sim TARGET=hw DATA_DIR=$(pwd)/data`
- `make -n -C aieml2 sim TARGET=hw DATA_DIR=$(pwd)/data`
- `make -n -C aieml3 sim TARGET=hw DATA_DIR=$(pwd)/data`
- `make -C aieml sim TARGET=hw DATA_DIR=$(pwd)/data` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a516f93cf48320a3f9dfc3fd19e101