### PR TITLE
Align AIE headers with shared include path

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -3,7 +3,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
-#include "../common/nn_defs.h"
+#include "nn_defs.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -69,7 +69,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -3,7 +3,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
-#include "../common/nn_defs.h"
+#include "nn_defs.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;


### PR DESCRIPTION
## Summary
- Use a common include path for AIE graph headers and add shared data header dependency
- Ensure all AIE Makefiles rebuild when common headers change

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++ not found)*
- `make -C aieml graph` *(fails: DSPLIB_PATH not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5184aa14c832083491d4561391b86