### PR TITLE
Use DATA_DIR macro for host data path

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -3,6 +3,8 @@
 # Toolchain and paths
 SYSROOT ?= /opt/petalinux/2024.2/sysroots/cortexa72-cortexa53-xilinx-linux
 CXX     := aarch64-linux-gnu-g++
+DATA_DIR ?= $(abspath ../data)
+export DATA_DIR
 
 # Sources and targets
 SRC := host.cpp
@@ -14,7 +16,8 @@ CXXFLAGS ?= -Wall -c -std=c++17 -Wno-int-to-pointer-cast \
         --sysroot=$(SYSROOT) \
         -I$(SYSROOT)/usr/include/xrt \
         -I$(SYSROOT)/usr/include \
-        -I./ -I./src/ -I../common -I/aietools/include -I/include
+        -I./ -I./src/ -I../common -I/aietools/include -I/include \
+        -DDATA_DIR='"$(DATA_DIR)"'
 
 LDFLAGS ?= --sysroot=$(SYSROOT) \
 	-L$(SYSROOT)/usr/lib \

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -35,8 +35,7 @@ int main(int argc, char** argv) {
 
     std::string xclbinFilename = argv[1];
 
-    // std::string base_path = DATA_DIR;
-    std::string base_path = "./data";
+    std::string base_path = DATA_DIR;
     std::string inputDataFile      = base_path + "/" + EMBED_INPUT_DATA;
     std::string weights1File       = base_path + "/" + EMBED_DENSE0_WEIGHTS;
     std::string weights2_part0File = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt";


### PR DESCRIPTION
## Summary
- Replace hardcoded data directory in `host.cpp` with `DATA_DIR`
- Export and embed `DATA_DIR` in host Makefile so executable finds data files

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++ not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a519ba7ac48320856ee8d85d44543d