### PR TITLE
Normalize DATA_DIR paths in AIE Makefiles

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -11,6 +11,7 @@ TARGET       ?= hw
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 DATA_DIR    ?= ../data
+DATA_DIR := $(abspath $(DATA_DIR))
 
 # Frequency for the Programmable Logic (PL) interfaces in MHz.
 PL_FREQ_MHZ  ?= 300

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -11,6 +11,7 @@ TARGET       ?= hw
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 DATA_DIR    ?= ../data
+DATA_DIR := $(abspath $(DATA_DIR))
 
 # Frequency for the Programmable Logic (PL) interfaces in MHz.
 PL_FREQ_MHZ  ?= 300

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -11,6 +11,7 @@ TARGET       ?= hw
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 DATA_DIR    ?= ../data
+DATA_DIR := $(abspath $(DATA_DIR))
 
 # Frequency for the Programmable Logic (PL) interfaces in MHz.
 PL_FREQ_MHZ  ?= 300


### PR DESCRIPTION
## Summary
- Resolve DATA_DIR to an absolute path in aieml, aieml2, and aieml3 Makefiles
- Ensure aiesimulator still receives DATA_DIR via environment variable

## Testing
- `make -n -C aieml sim`
- `make -n -C aieml2 sim`
- `make -n -C aieml3 sim`


------
https://chatgpt.com/codex/tasks/task_e_68a5203b16948320ab3f8a8417532d18