### PR TITLE
Define DATA_DIR for AIE builds

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -57,7 +57,8 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS)
+        $(AIE_INCLUDE_FLAGS) \
+        -DDATA_DIR='"$(DATA_DIR)"'
 
 
 # ==== RULES ====

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -57,7 +57,8 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS)
+        $(AIE_INCLUDE_FLAGS) \
+        -DDATA_DIR='"$(DATA_DIR)"'
 
 
 # ==== RULES ====

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -57,7 +57,8 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS)
+        $(AIE_INCLUDE_FLAGS) \
+        -DDATA_DIR='"$(DATA_DIR)"'
 
 
 # ==== RULES ====


### PR DESCRIPTION
## Summary
- Pass DATA_DIR as a compile-time define in all AIE Makefiles so simulation writes outputs to the correct top-level data directory

## Testing
- `make -C aieml graph TARGET=x86sim` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a51ef593b083209dcb4015c2776070