### PR TITLE
Remove DATA_DIR macro from AIE build flags

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -57,8 +57,7 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS) \
-        -DDATA_DIR='"$(DATA_DIR)"'
+        $(AIE_INCLUDE_FLAGS)
 
 
 # ==== RULES ====

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -57,8 +57,7 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS) \
-        -DDATA_DIR='"$(DATA_DIR)"'
+        $(AIE_INCLUDE_FLAGS)
 
 
 # ==== RULES ====

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -57,8 +57,7 @@ AIE_FLAGS := \
         --platform=$(PLATFORM) \
         --target=$(TARGET) \
         --pl-freq=$(PL_FREQ_MHZ) \
-        $(AIE_INCLUDE_FLAGS) \
-        -DDATA_DIR='"$(DATA_DIR)"'
+        $(AIE_INCLUDE_FLAGS)
 
 
 # ==== RULES ====


### PR DESCRIPTION
## Summary
- remove compile-time DATA_DIR definition from AIE build flags to rely on runtime variable

## Testing
- `make -C aieml graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a5265b3b388320b8f2f4e69d2ee284