### PR TITLE
Enable pipefail for AIE graph compilation

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -81,6 +81,7 @@ $(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
 		exit 1; \
 	fi
+	@set -o pipefail; \
 	$(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
 	@echo "COMPLETE: AIE graph compiled."
 

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -81,6 +81,7 @@ $(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
 		exit 1; \
 	fi
+	@set -o pipefail; \
 	$(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
 	@echo "COMPLETE: AIE graph compiled."
 

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -81,6 +81,7 @@ $(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
 		exit 1; \
 	fi
+	@set -o pipefail; \
 	$(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
 	@echo "COMPLETE: AIE graph compiled."
 


### PR DESCRIPTION
## Summary
- ensure aiecompiler failures stop the build by enabling pipefail in AIE Makefiles

## Testing
- `make -C aieml graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `make -C aieml2 graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `make -C aieml3 graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a527a7e9b48320b949ed838d7ee9ad