### PR TITLE
Use bash shell for AIE Makefile compile pipeline

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -2,6 +2,8 @@
 # Makefile for Vitis AIE Graph Compilation & Simulation
 # ===================================================================
 
+SHELL := /bin/bash
+
 # ==== CONFIG ====
 # Target platform for hardware compilation.
 PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm


### PR DESCRIPTION
## Summary
- use bash shell in AIE Makefile to support pipeline error detection
- retain `set -o pipefail` in compile recipe so pipeline errors surface

## Testing
- `cd aieml && make -n graph`


------
https://chatgpt.com/codex/tasks/task_e_68a52b18d0b0832088b1ed83ee300c0a