### PR TITLE
Ensure XSA rebuilds on linker config changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ endif
 # Create the platform XSA (system link). Ensure PL .xo and AIE lib exist first.
 link: $(XSA)
 
-$(XSA): $(AIE_LIB) $(PL_XOS)
+$(XSA): $(AIE_LIB) $(PL_XOS) $(LINK_CFG)
 	@echo "🔗 Linking with:"
 	@echo "    PL_XOS   = $(PL_XOS)"
 	@echo "    AIE_LIB  = $(AIE_LIB)"


### PR DESCRIPTION
## Summary
- Depend XSA link target on the active linker configuration file to force v++ to relink when the config changes

## Testing
- `make package` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a5d8966fd48320b64b3b34dcf22ebb