### PR TITLE
Remove link config from packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,8 @@ $(XCLBIN): link host $(POST_BOOT) | $(PKG_DIR)
 	@echo "    XSA      = $(XSA)"
 	@echo "    EXEC     = $(EXEC)"
 	@echo "Packaging design into $(PKG_DIR) as $@"
-	v++ --package $(PKG_FLAGS) $(PKG_COMMON) --config $(LINK_CFG) \
-	        $(AIE_LIB) $(XSA) -o $@
+	v++ --package $(PKG_FLAGS) $(PKG_COMMON) \
+		$(AIE_LIB) $(XSA) -o $@
 	@echo "✅ Packaged design created in $(PKG_DIR)"
 
 $(PKG_DIR):


### PR DESCRIPTION
## Summary
- avoid passing link configuration file to `v++ --package`

## Testing
- `make clean`
- `make link package` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68a5dcbef2308320bcfc73388270bc4b