### PR TITLE
Conditionally set HLS kernels for aieml3 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,13 @@ LINK_CFG  := ./common/linker_$(GRAPH).cfg
 # Location for generated input and output files. Default to a directory one
 # level above the project to keep the repository tree clean.
 DATA_DIR  ?= $(abspath ./data)
-HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
+
+ifeq ($(GRAPH),aieml3)
+  HLS_KERNELS := mm2s leaky_relu s2mm
+else
+  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
+endif
+
 POST_BOOT := post_boot.sh
 ###########################################################################
 


### PR DESCRIPTION
## Summary
- Make HLS kernel list conditional on `GRAPH` to omit `leaky_splitter` when targeting `aieml3`

## Testing
- `make clean`
- `make aieml3 link` *(fails: Directory not found for Vitis DSP library)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ead8e0e08320aab589ea7032b943