### PR TITLE
Make leaky ReLU kernel size configurable

### DIFF
--- a/pl/src/leaky_relu_pl.cpp
+++ b/pl/src/leaky_relu_pl.cpp
@@ -7,16 +7,18 @@ typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
 
 extern "C" {
-    // Apply bias then leaky ReLU to HIDDEN_SIZE elements
+    // Apply bias then leaky ReLU to `size` elements
     void leaky_relu_pl(hls::stream<axis_t>& in_stream,
                        hls::stream<axis_t>& bias_stream,
-                       hls::stream<axis_t>& out_stream) {
-        #pragma HLS interface axis port=in_stream bundle=gmem depth=HIDDEN_SIZE
-        #pragma HLS interface axis port=bias_stream bundle=gmem depth=HIDDEN_SIZE
-        #pragma HLS interface axis port=out_stream bundle=gmem depth=HIDDEN_SIZE
+                       hls::stream<axis_t>& out_stream,
+                       int size) {
+        #pragma HLS interface axis port=in_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
+        #pragma HLS interface axis port=bias_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
+        #pragma HLS interface axis port=out_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
+        #pragma HLS INTERFACE s_axilite port=size bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-        for (int i = 0; i < HIDDEN_SIZE; i++) {
+        for (int i = 0; i < size; i++) {
             #pragma HLS pipeline II=1
             axis_t val       = in_stream.read();
             axis_t bias_val  = bias_stream.read();

--- a/pl/src/leaky_relu_test.cpp
+++ b/pl/src/leaky_relu_test.cpp
@@ -12,7 +12,8 @@ typedef hls::axis<data_t, 0, 0, 0> axis_t;
 extern "C" {
     void leaky_relu_pl(hls::stream<axis_t>& in_stream,
                        hls::stream<axis_t>& bias_stream,
-                       hls::stream<axis_t>& out_stream);
+                       hls::stream<axis_t>& out_stream,
+                       int size);
 }
 
 int main() {
@@ -55,7 +56,7 @@ int main() {
     fin_data.close();
     fin_bias.close();
 
-    leaky_relu_pl(in_stream, bias_stream, out_stream);
+    leaky_relu_pl(in_stream, bias_stream, out_stream, HIDDEN_SIZE);
 
     std::ofstream fout(std::string(DATA_DIR) + "/leakyrelu_output_pl.txt");
     if (!fout.is_open()) {


### PR DESCRIPTION
## Summary
- Allow leaky ReLU HLS kernel to process a runtime-specified number of elements
- Pass element count from host application when launching leaky ReLU kernels

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make -C pl` *(fails: vitis_hls: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a633d3b4fc83208f810f75a3e80ece