### PR TITLE
Add roll_concat kernel project and simulation data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ LINK_CFG  := ./common/linker_$(GRAPH).cfg
 DATA_DIR  ?= $(abspath ./data)
 
 ifeq ($(GRAPH),aieml3)
-  HLS_KERNELS := mm2s leaky_relu s2mm
+  HLS_KERNELS := mm2s leaky_relu roll_concat s2mm
 else
-  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
+  HLS_KERNELS := mm2s leaky_relu leaky_splitter roll_concat s2mm
 endif
 
 POST_BOOT := post_boot.sh

--- a/common/nn_defs.h
+++ b/common/nn_defs.h
@@ -5,7 +5,7 @@ constexpr int HIDDEN_SIZE = 128;
 constexpr int OUTPUT_SIZE = 128;
 constexpr float LEAKY_SLOPE = 0.1f;
 constexpr int CASCADE_LENGTH = 2;
-constexpr int ROLL_CONC_SUBSET_SIZE 6
+constexpr int ROLL_CONC_SUBSET_SIZE = 6;
 
 
 constexpr int EMBED_DENSE0_INPUT_SIZE = INPUT_SIZE;

--- a/pl/Makefile
+++ b/pl/Makefile
@@ -6,7 +6,7 @@
 VITIS_HLS ?= vitis_hls
 
 # List of kernels (add more as needed)
-KERNELS ?= mm2s leaky_relu leaky_splitter s2mm
+KERNELS ?= mm2s leaky_relu leaky_splitter s2mm roll_concat
 # KERNELS := leaky_relu
 
 

--- a/pl/roll_concat_project.tcl
+++ b/pl/roll_concat_project.tcl
@@ -1,0 +1,77 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'roll_concat'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "roll_concat"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "roll_concat_pl"
+set kernel_file  "src/roll_concat_pl.cpp"
+set tb_file      "src/roll_concat_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+# Add your project's specific source files from src/
+add_files $kernel_file
+add_files -tb $tb_file
+add_files -tb ../data/embed_model_output.txt
+
+# Use the -flow_target vitis flag for correct XO generation
+open_solution -flow_target vitis "solution1"
+
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" {
+        puts "### Running C Simulation... ###"
+        csim_design
+    }
+    "csynth" {
+        puts "### Running C Synthesis... ###"
+        csynth_design
+    }
+    "cosim" {
+        puts "### Running Synthesis and Co-simulation... ###"
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        puts "### Running Synthesis and Exporting IP... ###"
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        puts "### Running Synthesis and Exporting XO... ###"
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        puts "### Running Synthesis... ###"
+        csynth_design
+        puts "### Exporting XO and IP Catalog... ###"
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default {
+        puts "ERROR: Unknown command '$command'."
+    }
+}
+
+close_project
+exit

--- a/pl/src/roll_concat_pl.cpp
+++ b/pl/src/roll_concat_pl.cpp
@@ -10,9 +10,8 @@ void roll_concat(hls::stream<data_t> &in, hls::stream<data_t> &out) {
 #pragma HLS INTERFACE axis port=in
 #pragma HLS INTERFACE axis port=out
 #pragma HLS INTERFACE ap_ctrl_none port=return
-#pragma HLS ARRAY_PARTITION variable=buffer complete dim=1
-
     data_t buffer[HIDDEN_SIZE];
+#pragma HLS ARRAY_PARTITION variable=buffer complete dim=1
 
     // Read input vector
     for (int i = 0; i < HIDDEN_SIZE; i++) {

--- a/pl/src/roll_concat_test.cpp
+++ b/pl/src/roll_concat_test.cpp
@@ -1,6 +1,7 @@
 #include <hls_stream.h>
 #include <iostream>
 #include <cmath>
+#include <fstream>
 #include "../../common/nn_defs.h"
 
 #define OUTPUT_SIZE (HIDDEN_SIZE * ROLL_CONC_SUBSET_SIZE)
@@ -26,11 +27,17 @@ int main() {
     data_t ref_output[OUTPUT_SIZE];
     data_t test_output[OUTPUT_SIZE];
 
-    // Initialize input with known pattern
+    // Read input vector from file
+    std::ifstream infile("../data/embed_model_output.txt");
+    if (!infile) {
+        std::cerr << "Failed to open input file" << std::endl;
+        return 1;
+    }
     for (int i = 0; i < HIDDEN_SIZE; i++) {
-        input[i] = (data_t)i;
+        infile >> input[i];
         in_stream.write(input[i]);
     }
+    infile.close();
 
     // Run kernel
     roll_concat(in_stream, out_stream);


### PR DESCRIPTION
## Summary
- define ROLL_CONC_SUBSET_SIZE constant
- partition roll_concat buffer and test against real model output
- integrate roll_concat into build system and add project TCL script

## Testing
- `make -C pl KERNELS=roll_concat sim` *(fails: vitis_hls not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a647445a088320b005a6b151ec58a0