### PR TITLE
Use defined constants for leaky splitter paths

### DIFF
--- a/pl/src/leaky_splitter_test.cpp
+++ b/pl/src/leaky_splitter_test.cpp
@@ -18,7 +18,7 @@ int main() {
     hls::stream<axis_t> in_stream;
     hls::stream<axis_t> out_stream[CASCADE_LENGTH];
 
-    std::ifstream fin(std::string(DATA_DIR) + "/leakyrelu_output_ref.txt");
+    std::ifstream fin(std::string(DATA_DIR) + "/" + EMBED_LEAKYRELU0_OUTPUT);
     if (!fin.is_open()) {
         std::cerr << "ERROR: Cannot open dense1_output_ref.txt" << std::endl;
         return 1;
@@ -38,8 +38,8 @@ int main() {
     leaky_splitter_pl(in_stream, out_stream);
 
     std::ofstream fout[CASCADE_LENGTH];
-    fout[0].open(std::string(DATA_DIR) + "/leakyrelu_output_pl_part0.txt");
-    fout[1].open(std::string(DATA_DIR) + "/leakyrelu_output_pl_part1.txt");
+    fout[0].open(std::string(DATA_DIR) + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + "0.txt");
+    fout[1].open(std::string(DATA_DIR) + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + "1.txt");
 
     for (int i = 0; i < CASCADE_LENGTH; ++i) {
         if (!fout[i].is_open()) {


### PR DESCRIPTION
## Summary
- Refactor leaky splitter test bench to reference shared path constants for input and split outputs.

## Testing
- `g++ pl/src/leaky_splitter_test.cpp pl/src/leaky_splitter_pl.cpp -std=c++11 -I. -Ihls_stub -o leaky_splitter_test`

------
https://chatgpt.com/codex/tasks/task_e_68a65099c4188320ac82d3efe1b97296