### PR TITLE
Fix roll concat test path resolution

### DIFF
--- a/pl/src/roll_concat_test.cpp
+++ b/pl/src/roll_concat_test.cpp
@@ -29,7 +29,7 @@ int main() {
     data_t test_output[OUTPUT_SIZE];
 
     // Read input vector from file
-    std::ifstream infile("../"+ std::string(DATA_DIR) + "/" + std::string(EMBED_MODEL_OUTPUT));
+    std::ifstream infile(std::string(DATA_DIR) + "/" + EMBED_MODEL_OUTPUT);
     if (!infile.is_open()) {
         std::cerr << "ERROR: Cannot open EMBED_MODEL_OUTPUT" << std::endl;
         return 1;


### PR DESCRIPTION
## Summary
- remove hardcoded `../` prefix when loading roll_concat input data so `DATA_DIR` is used directly

## Testing
- `make -C pl KERNELS=roll_concat TARGET=csim sim` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a650b537e8832098d1f593a901f17a