### PR TITLE
Use data_paths macro for s2mm golden output

### DIFF
--- a/pl/src/s2mm_test.cpp
+++ b/pl/src/s2mm_test.cpp
@@ -17,9 +17,9 @@ int main() {
     std::vector<data_t> golden_data;
     golden_data.reserve(SIZE);
 
-    std::ifstream fin(std::string(DATA_DIR) + "/output_data_ref.txt");
+    std::ifstream fin(std::string(DATA_DIR) + "/" + OUTPUT_DENSE0_OUTPUT);
     if (!fin.is_open()) {
-        std::cerr << "ERROR: Cannot open input file leakyrelu_output_ref.txt" << std::endl;
+        std::cerr << "ERROR: Cannot open " << OUTPUT_DENSE0_OUTPUT << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- use `OUTPUT_DENSE0_OUTPUT` macro for golden data path in `s2mm_test`
- improve error reporting when golden data file can't be opened

## Testing
- `g++ -std=c++17 pl/src/s2mm_test.cpp -o s2mm_test` *(fails: fatal error: hls_stream.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a651b255ec8320b5ffcd21f1befda9