### PR TITLE
Share mm2s kernel across layers with runtime scheduling

### DIFF
--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -1,20 +1,23 @@
 [connectivity]
-# Define the number of compute units (CU) for each kernel.
-# This instantiates 6 CUs of mm2s_pl, and 1 for each of the other kernels.
-
-nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,mm2s_bias2
-
+# Instantiate a single shared mm2s kernel.  An AXI4-Stream switch fans the
+# output of this kernel to the various AI Engine and PL sinks.
+nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
 nk=s2mm_pl:1:s2mm_out
+nk=axis_switch:1:mm2s_switch
 
 # --- Stream Connections ---
+# mm2s -> AXI4-Stream switch
+stream_connect=mm2s.s:mm2s_switch.S00_AXIS
 
-# Layer 0: Data and weights streamed from memory into the AIE graph for dense8x128
-stream_connect=mm2s_din.s:ai_engine_0.layer0_in
-stream_connect=mm2s_weights1.s:ai_engine_0.layer0_weights
-
-stream_connect=mm2s_bias1.s:relu.bias_stream
+# Switch outputs to the AIE/PL ports
+stream_connect=mm2s_switch.M00_AXIS:ai_engine_0.layer0_in
+stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.layer0_weights
+stream_connect=mm2s_switch.M02_AXIS:ai_engine_0.layer1_weights_0
+stream_connect=mm2s_switch.M03_AXIS:ai_engine_0.layer1_weights_1
+stream_connect=mm2s_switch.M04_AXIS:relu.bias_stream
+stream_connect=mm2s_switch.M05_AXIS:relu2.bias_stream
 
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
 stream_connect=ai_engine_0.layer0_out:relu.in_stream
@@ -22,13 +25,8 @@ stream_connect=relu.out_stream:splitter.in_stream
 stream_connect=splitter.out_stream_0:ai_engine_0.layer1_in_0
 stream_connect=splitter.out_stream_1:ai_engine_0.layer1_in_1
 
-# Layer 1: Weights streamed from memory into the AIE graph dense128x128
-stream_connect=mm2s_weights2_0.s:ai_engine_0.layer1_weights_0
-stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
-
-stream_connect=mm2s_bias2.s:relu2.bias_stream
-
-# Final output from the AIE graph passes through a second LeakyReLU before being written to memory
+# Final output from the AIE graph passes through a second LeakyReLU before
+# being written to memory
 stream_connect=ai_engine_0.layer1_out:relu2.in_stream
 stream_connect=relu2.out_stream:s2mm_out.s
 

--- a/common/linker_aieml2.cfg
+++ b/common/linker_aieml2.cfg
@@ -1,63 +1,72 @@
 [connectivity]
-# Define mm2s compute units for inputs, weights, and biases
-nk=mm2s_pl:34:layer0_in_0,layer0_in_1,layer0_in_2,layer0_in_3,layer0_in_4,layer0_in_5,layer0_in_6,layer0_in_7,layer0_in_8,layer0_in_9,layer0_in_10,layer0_in_11,layer0_weights_0,layer0_weights_1,layer0_weights_2,layer0_weights_3,layer0_weights_4,layer0_weights_5,layer0_weights_6,layer0_weights_7,layer0_weights_8,layer0_weights_9,layer0_weights_10,layer0_weights_11,layer1_weights_0,layer1_weights_1,layer2_weights_0,layer2_weights_1,layer3_weights_0,layer3_weights_1,bias0,bias1,bias2,bias3
-
+# A single shared mm2s kernel with an AXI4-Stream switch driving the many
+# AI Engine input and bias ports.
+nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:4:relu0,relu1,relu2,relu3
 nk=leaky_splitter_pl:3:split0,split1,split2
 nk=s2mm_pl:1:s2mm_out
+nk=axis_switch:1:mm2s_switch
 
 # --- Stream Connections ---
+stream_connect=mm2s.s:mm2s_switch.S00_AXIS
 
-# Layer 0: Inputs and weights streamed from memory into the AIE graph
-stream_connect=layer0_in_0.s:ai_engine_0.layer0_in_0
-stream_connect=layer0_in_1.s:ai_engine_0.layer0_in_1
-stream_connect=layer0_in_2.s:ai_engine_0.layer0_in_2
-stream_connect=layer0_in_3.s:ai_engine_0.layer0_in_3
-stream_connect=layer0_in_4.s:ai_engine_0.layer0_in_4
-stream_connect=layer0_in_5.s:ai_engine_0.layer0_in_5
-stream_connect=layer0_in_6.s:ai_engine_0.layer0_in_6
-stream_connect=layer0_in_7.s:ai_engine_0.layer0_in_7
-stream_connect=layer0_in_8.s:ai_engine_0.layer0_in_8
-stream_connect=layer0_in_9.s:ai_engine_0.layer0_in_9
-stream_connect=layer0_in_10.s:ai_engine_0.layer0_in_10
-stream_connect=layer0_in_11.s:ai_engine_0.layer0_in_11
-stream_connect=layer0_weights_0.s:ai_engine_0.layer0_weights_0
-stream_connect=layer0_weights_1.s:ai_engine_0.layer0_weights_1
-stream_connect=layer0_weights_2.s:ai_engine_0.layer0_weights_2
-stream_connect=layer0_weights_3.s:ai_engine_0.layer0_weights_3
-stream_connect=layer0_weights_4.s:ai_engine_0.layer0_weights_4
-stream_connect=layer0_weights_5.s:ai_engine_0.layer0_weights_5
-stream_connect=layer0_weights_6.s:ai_engine_0.layer0_weights_6
-stream_connect=layer0_weights_7.s:ai_engine_0.layer0_weights_7
-stream_connect=layer0_weights_8.s:ai_engine_0.layer0_weights_8
-stream_connect=layer0_weights_9.s:ai_engine_0.layer0_weights_9
-stream_connect=layer0_weights_10.s:ai_engine_0.layer0_weights_10
-stream_connect=layer0_weights_11.s:ai_engine_0.layer0_weights_11
+# Layer 0 inputs (0-11)
+stream_connect=mm2s_switch.M00_AXIS:ai_engine_0.layer0_in_0
+stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.layer0_in_1
+stream_connect=mm2s_switch.M02_AXIS:ai_engine_0.layer0_in_2
+stream_connect=mm2s_switch.M03_AXIS:ai_engine_0.layer0_in_3
+stream_connect=mm2s_switch.M04_AXIS:ai_engine_0.layer0_in_4
+stream_connect=mm2s_switch.M05_AXIS:ai_engine_0.layer0_in_5
+stream_connect=mm2s_switch.M06_AXIS:ai_engine_0.layer0_in_6
+stream_connect=mm2s_switch.M07_AXIS:ai_engine_0.layer0_in_7
+stream_connect=mm2s_switch.M08_AXIS:ai_engine_0.layer0_in_8
+stream_connect=mm2s_switch.M09_AXIS:ai_engine_0.layer0_in_9
+stream_connect=mm2s_switch.M10_AXIS:ai_engine_0.layer0_in_10
+stream_connect=mm2s_switch.M11_AXIS:ai_engine_0.layer0_in_11
 
-stream_connect=bias0.s:relu0.bias_stream
+# Layer 0 weights (12-23)
+stream_connect=mm2s_switch.M12_AXIS:ai_engine_0.layer0_weights_0
+stream_connect=mm2s_switch.M13_AXIS:ai_engine_0.layer0_weights_1
+stream_connect=mm2s_switch.M14_AXIS:ai_engine_0.layer0_weights_2
+stream_connect=mm2s_switch.M15_AXIS:ai_engine_0.layer0_weights_3
+stream_connect=mm2s_switch.M16_AXIS:ai_engine_0.layer0_weights_4
+stream_connect=mm2s_switch.M17_AXIS:ai_engine_0.layer0_weights_5
+stream_connect=mm2s_switch.M18_AXIS:ai_engine_0.layer0_weights_6
+stream_connect=mm2s_switch.M19_AXIS:ai_engine_0.layer0_weights_7
+stream_connect=mm2s_switch.M20_AXIS:ai_engine_0.layer0_weights_8
+stream_connect=mm2s_switch.M21_AXIS:ai_engine_0.layer0_weights_9
+stream_connect=mm2s_switch.M22_AXIS:ai_engine_0.layer0_weights_10
+stream_connect=mm2s_switch.M23_AXIS:ai_engine_0.layer0_weights_11
+
+# Layer 1-3 weights (24-29)
+stream_connect=mm2s_switch.M24_AXIS:ai_engine_0.layer1_weights_0
+stream_connect=mm2s_switch.M25_AXIS:ai_engine_0.layer1_weights_1
+stream_connect=mm2s_switch.M26_AXIS:ai_engine_0.layer2_weights_0
+stream_connect=mm2s_switch.M27_AXIS:ai_engine_0.layer2_weights_1
+stream_connect=mm2s_switch.M28_AXIS:ai_engine_0.layer3_weights_0
+stream_connect=mm2s_switch.M29_AXIS:ai_engine_0.layer3_weights_1
+
+# Biases for each layer (30-33)
+stream_connect=mm2s_switch.M30_AXIS:relu0.bias_stream
+stream_connect=mm2s_switch.M31_AXIS:relu1.bias_stream
+stream_connect=mm2s_switch.M32_AXIS:relu2.bias_stream
+stream_connect=mm2s_switch.M33_AXIS:relu3.bias_stream
+
+# Existing AIE graph connections
 stream_connect=ai_engine_0.layer0_out:relu0.in_stream
 stream_connect=relu0.out_stream:split0.in_stream
 stream_connect=split0.out_stream_0:ai_engine_0.layer1_in_0
 stream_connect=split0.out_stream_1:ai_engine_0.layer1_in_1
 
-stream_connect=layer1_weights_0.s:ai_engine_0.layer1_weights_0
-stream_connect=layer1_weights_1.s:ai_engine_0.layer1_weights_1
-stream_connect=bias1.s:relu1.bias_stream
 stream_connect=ai_engine_0.layer1_out:relu1.in_stream
 stream_connect=relu1.out_stream:split1.in_stream
 stream_connect=split1.out_stream_0:ai_engine_0.layer2_in_0
 stream_connect=split1.out_stream_1:ai_engine_0.layer2_in_1
 
-stream_connect=layer2_weights_0.s:ai_engine_0.layer2_weights_0
-stream_connect=layer2_weights_1.s:ai_engine_0.layer2_weights_1
-stream_connect=bias2.s:relu2.bias_stream
 stream_connect=ai_engine_0.layer2_out:relu2.in_stream
 stream_connect=relu2.out_stream:split2.in_stream
 stream_connect=split2.out_stream_0:ai_engine_0.layer3_in_0
 stream_connect=split2.out_stream_1:ai_engine_0.layer3_in_1
 
-stream_connect=layer3_weights_0.s:ai_engine_0.layer3_weights_0
-stream_connect=layer3_weights_1.s:ai_engine_0.layer3_weights_1
-stream_connect=bias3.s:relu3.bias_stream
 stream_connect=ai_engine_0.layer3_out:relu3.in_stream
 stream_connect=relu3.out_stream:s2mm_out.s

--- a/common/linker_aieml3.cfg
+++ b/common/linker_aieml3.cfg
@@ -1,14 +1,15 @@
 [connectivity]
-# Define mm2s compute units for input, weights and bias
-nk=mm2s_pl:3:mm2s_din,mm2s_weights,mm2s_bias
+# Single mm2s kernel with AXI4-Stream switch for input, weights and bias
+nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:1:relu
 nk=s2mm_pl:1:s2mm_out
+nk=axis_switch:1:mm2s_switch
 
 # --- Stream Connections ---
-# Data and weights streamed from memory into the AIE graph
-stream_connect=mm2s_din.s:ai_engine_0.layer0_in
-stream_connect=mm2s_weights.s:ai_engine_0.layer0_weights
-stream_connect=mm2s_bias.s:relu.bias_stream
+stream_connect=mm2s.s:mm2s_switch.S00_AXIS
+stream_connect=mm2s_switch.M00_AXIS:ai_engine_0.layer0_in
+stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.layer0_weights
+stream_connect=mm2s_switch.M02_AXIS:relu.bias_stream
 
 # AIE output passes through LeakyReLU before being written back to memory
 stream_connect=ai_engine_0.layer0_out:relu.in_stream

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -32,7 +32,8 @@ static std::vector<float> read_file_to_vector(const std::string& filename, int s
     return data;
 }
 
-struct MM2SInfo { std::string file; int size; std::string kernel; };
+// Description of a transfer to be issued by the shared MM2S kernel
+struct MM2SInfo { std::string file; int size; };
 
 struct GraphConfig {
     std::vector<MM2SInfo> mm2s;
@@ -48,12 +49,12 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
     if (graph == "aieml") {
         GraphConfig cfg;
         cfg.mm2s = {
-            {base_path + "/" + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE, "mm2s_pl:{mm2s_weights1}"},
-            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, "mm2s_pl:{mm2s_weights2_0}"},
-            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "1.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, "mm2s_pl:{mm2s_weights2_1}"},
-            {base_path + "/" + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE, "mm2s_pl:{mm2s_bias1}"},
-            {base_path + "/" + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE, "mm2s_pl:{mm2s_bias2}"},
-            {base_path + "/" + EMBED_INPUT_DATA, EMBED_DENSE0_INPUT_SIZE, "mm2s_pl:{mm2s_din}"},
+            {base_path + "/" + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE},
+            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE},
+            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "1.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE},
+            {base_path + "/" + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE},
+            {base_path + "/" + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE},
+            {base_path + "/" + EMBED_INPUT_DATA, EMBED_DENSE0_INPUT_SIZE},
         };
         cfg.relus = {"leaky_relu_pl:{relu}", "leaky_relu_pl:{relu2}"};
         cfg.splitters = {"leaky_splitter_pl:{splitter}"};
@@ -67,38 +68,32 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
         // Layer 0 weights
         for (int i = 0; i < SUBSOLVER0_INPUT_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
-                                SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer0_weights_" + std::to_string(i) + "}"});
+                                SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE});
         }
         // Layer 1-3 weights
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
-                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer1_weights_" + std::to_string(i) + "}"});
+                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE});
         }
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
-                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer2_weights_" + std::to_string(i) + "}"});
+                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE});
         }
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
-                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer3_weights_" + std::to_string(i) + "}"});
+                                SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE});
         }
         // Biases
         std::vector<std::string> bias_files = {SUBSOLVER0_DENSE0_BIAS, SUBSOLVER0_DENSE1_BIAS,
                                                SUBSOLVER0_DENSE2_BIAS, SUBSOLVER0_DENSE3_BIAS};
         for (int i = 0; i < 4; ++i) {
             cfg.mm2s.push_back({base_path + "/" + bias_files[i],
-                                SUBSOLVER0_LAYER_BIAS_SIZE,
-                                "mm2s_pl:{bias" + std::to_string(i) + "}"});
+                                SUBSOLVER0_LAYER_BIAS_SIZE});
         }
         // Inputs for layer 0
         for (int i = 0; i < SUBSOLVER0_INPUT_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX + std::to_string(i) + ".txt",
-                                SUBSOLVER0_INPUT_PART_SIZE,
-                                "mm2s_pl:{layer0_in_" + std::to_string(i) + "}"});
+                                SUBSOLVER0_INPUT_PART_SIZE});
         }
         cfg.relus = {"leaky_relu_pl:{relu0}", "leaky_relu_pl:{relu1}", "leaky_relu_pl:{relu2}", "leaky_relu_pl:{relu3}"};
         cfg.splitters = {"leaky_splitter_pl:{split0}", "leaky_splitter_pl:{split1}", "leaky_splitter_pl:{split2}"};
@@ -110,9 +105,9 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
     } else if (graph == "aieml3") {
         GraphConfig cfg;
         cfg.mm2s = {
-            {base_path + "/" + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE, "mm2s_pl:{mm2s_weights}"},
-            {base_path + "/" + OUTPUT_DENSE0_BIAS,    OUTPUT_DENSE0_BIAS_SIZE,    "mm2s_pl:{mm2s_bias}"},
-            {base_path + "/" + OUTPUT_INPUT_DATA,     OUTPUT_DENSE0_INPUT_SIZE,   "mm2s_pl:{mm2s_din}"},
+            {base_path + "/" + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE},
+            {base_path + "/" + OUTPUT_DENSE0_BIAS,    OUTPUT_DENSE0_BIAS_SIZE},
+            {base_path + "/" + OUTPUT_INPUT_DATA,     OUTPUT_DENSE0_INPUT_SIZE},
         };
         cfg.relus = {"leaky_relu_pl:{relu}"};
         cfg.splitters = {};
@@ -156,10 +151,8 @@ int main(int argc, char** argv) {
         xrt::bo output_buf(device, cfg.output_size * sizeof(float), xrt::bo::flags::normal, 0);
 
         // Acquire kernel and graph handles
-        std::vector<xrt::kernel> mm2s_kernels;
-        for (auto& spec : cfg.mm2s) {
-            mm2s_kernels.emplace_back(device, xclbin_uuid, spec.kernel.c_str());
-        }
+        // A single mm2s kernel is shared across all transfers
+        xrt::kernel mm2s_kernel(device, xclbin_uuid, "mm2s_pl:{mm2s}");
         std::vector<xrt::kernel> relu_kernels;
         for (auto& name : cfg.relus) {
             relu_kernels.emplace_back(device, xclbin_uuid, name.c_str());
@@ -190,17 +183,18 @@ int main(int argc, char** argv) {
         // Run AIE graph
         aie_graph.run(1);
 
-        // Start producers
-        std::vector<xrt::run> mm2s_runs;
-        for (size_t i = 0; i < mm2s_kernels.size(); ++i) {
-            auto run = xrt::run(mm2s_kernels[i]);
+        // Start producers sequentially, reprogramming the mm2s kernel for each
+        // required transfer.  This allows a single kernel instance to service
+        // all layers in turn.
+        for (size_t i = 0; i < cfg.mm2s.size(); ++i) {
+            auto run = xrt::run(mm2s_kernel);
             run.set_arg(0, mm2s_bos[i]);
-            run.set_arg(2, cfg.mm2s[i].size);
+            run.set_arg(2, 0);                    // offset within the buffer
+            run.set_arg(3, cfg.mm2s[i].size);     // transfer length
             run.start();
-            mm2s_runs.push_back(std::move(run));
+            run.wait();
         }
 
-        for (auto& r : mm2s_runs) r.wait();
         aie_graph.wait();
         s2mm_run.wait();
 

--- a/pl/src/mm2s_pl.cpp
+++ b/pl/src/mm2s_pl.cpp
@@ -6,8 +6,10 @@ typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
 
 extern "C" {
-    // Move data from memory to an AXI stream
-    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int size) {
+    // Move data from memory to an AXI stream.  The memory pointer and
+    // transfer length are provided at run time so the same kernel instance
+    // can be reused for any block of data without recompilation.
+    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size) {
         #pragma HLS INTERFACE m_axi port=mem offset=slave bundle=gmem depth=4096
         #ifndef __SYNTHESIS__
             #pragma HLS INTERFACE axis port=s depth=4096
@@ -15,12 +17,16 @@ extern "C" {
             #pragma HLS INTERFACE axis port=s
         #endif
         #pragma HLS INTERFACE s_axilite port=mem bundle=control
+        #pragma HLS INTERFACE s_axilite port=offset bundle=control
         #pragma HLS INTERFACE s_axilite port=size bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
+        // Start reading from the specified offset so arbitrary sub-buffers can
+        // be transmitted.
         for (int i = 0; i < size; ++i) {
             #pragma HLS PIPELINE II=1
-            axis_t val; val.data = mem[i];
+            axis_t val;
+            val.data = mem[offset + i];
             s.write(val);
         }
     }

--- a/system_project.yaml
+++ b/system_project.yaml
@@ -24,6 +24,7 @@ components:
       - mm2s_8_128.xo
       - s2mm_16_128.xo
       - s2mm_32_128.xo
+      - axis_switch.xo
 
   - name: hw_link_output
     type: xsa


### PR DESCRIPTION
## Summary
- Allow mm2s kernel to use runtime pointer offsets and lengths
- Rework host to reuse single mm2s kernel sequentially for all transfers
- Connect all AI Engine ports through a shared mm2s/s2mm pair with an AXI4-Stream switch

## Testing
- `make` (fails: aarch64-linux-gnu-g++: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a66867f05483208a0c76273b5234b5