### PR TITLE
Add compile-time flag for DMA weight preloading

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -10,6 +10,7 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
+USE_PRELOADED_WEIGHTS ?= 0
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Defaults two levels up so data lives outside the source tree when building
@@ -63,10 +64,14 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
+ifeq ($(USE_PRELOADED_WEIGHTS),1)
+AIE_FLAGS += --define=USE_PRELOADED_WEIGHTS
+endif
+
 
 # ==== RULES ====
 
-.PHONY: all graph sim clean
+.PHONY: all graph sim clean aiesim hw
 
 # --- Default Target ---
 all: graph
@@ -109,4 +114,10 @@ clean:
 	       pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
 	       *.json *.vcd
 	@echo "CLEANED: Build and work directories removed."
+
+aiesim: TARGET=hw
+aiesim: sim
+
+hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: graph
 

--- a/aieml/README.md
+++ b/aieml/README.md
@@ -19,32 +19,21 @@ programmable logic. Later stages are implemented in
 
 ## Build
 
-The supplied `Makefile` wraps the standard build flow. From the repository
-root, compile the graph with:
+The `Makefile` provides two convenience targets:
 
-```bash
-cd aieml
-make graph TARGET=hw       # or TARGET=x86sim
-```
+- `make aiesim` – compile and run cycle-accurate simulation using file-based
+  weights.
+- `make hw` – build the graph for hardware. This defines the
+  `USE_PRELOADED_WEIGHTS` flag so weights are delivered through the shared DMA
+  stream.
 
-To invoke the compiler directly without the wrapper:
+Both commands produce `Work/libadf.a` inside this directory. To invoke the
+compiler directly without the wrapper:
 
 ```bash
 cd aieml
 v++ --compile --mode aie --target hw ./graph.cpp \
     --platform=${PLATFORM} -I./data
-```
-
-Both commands produce `Work/libadf.a` inside this directory.
-
-## Simulation
-
-After a successful build, run cycle-approximate simulation:
-
-```bash
-make sim TARGET=hw        # uses `aiesimulator` under the hood
-# or run manually
-# aiesimulator --pkg-dir=Work --profile --dump-vcd=foo
 ```
 
 ## Data Flow

--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -4,7 +4,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
-#ifndef __AIESIM__
+#ifdef USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -54,7 +54,7 @@ public:
     input_plio  layer1_in[TP_CASC_LEN_LAYER2];
     output_plio layer1_out;
 
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
     input_plio  layer0_weights;
     input_plio  layer1_weights[TP_CASC_LEN_LAYER2];
 #else
@@ -80,7 +80,7 @@ public:
         layer0_out = output_plio::create("layer0_out", plio_32_bits,
                                         (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
 
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
         layer0_weights = input_plio::create("layer0_weights", plio_32_bits,
                                             (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
         connect<>(layer0_weights.out[0], dense1.inA[0]);
@@ -94,7 +94,7 @@ public:
             std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
             std::string in_name = "layer1_in_" + std::to_string(i);
             layer1_in[i] = input_plio::create(in_name.c_str(), plio_32_bits, in_file.c_str());
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
             std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
             std::string w_name  = "layer1_weights_" + std::to_string(i);
             layer1_weights[i] = input_plio::create(w_name.c_str(), plio_32_bits, w_file.c_str());

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -10,6 +10,7 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
+USE_PRELOADED_WEIGHTS ?= 0
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Default outside the repository when this subdirectory is built directly.
@@ -62,10 +63,14 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
+ifeq ($(USE_PRELOADED_WEIGHTS),1)
+AIE_FLAGS += --define=USE_PRELOADED_WEIGHTS
+endif
+
 
 # ==== RULES ====
 
-.PHONY: all graph sim clean
+.PHONY: all graph sim clean aiesim hw
 
 # --- Default Target ---
 all: graph
@@ -108,4 +113,10 @@ clean:
 	       pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
 	       *.json *.vcd
 	@echo "CLEANED: Build and work directories removed."
+
+aiesim: TARGET=hw
+aiesim: sim
+
+hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: graph
 

--- a/aieml2/README.md
+++ b/aieml2/README.md
@@ -16,21 +16,12 @@ those files to be overridden with the `DATA_DIR` environment variable.
 
 ## Build
 
-From the repository root, compile the graph:
+Two wrapper targets are provided:
 
-```bash
-cd aieml2
-make graph TARGET=hw       # or TARGET=x86sim
-```
+- `make aiesim` – compile and simulate the graph with file-based weights.
+- `make hw` – build for hardware. This enables the `USE_PRELOADED_WEIGHTS`
+  macro so that weights are supplied by a shared DMA stream.
 
-## Simulation
-
-After a successful build, run cycle‑approximate simulation:
-
-```bash
-make sim TARGET=hw        # uses `aiesimulator`
-```
-
-Simulation reads all inputs from `DATA_DIR` and writes layer outputs back to
-the same location.
+Both commands write the compiled artefacts to `Work/`. Simulation reads all
+inputs from `DATA_DIR` and writes layer outputs back to the same location.
 

--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -4,7 +4,7 @@
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
 #include "nn_defs.h"
-#ifndef __AIESIM__
+#ifdef USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -88,7 +88,7 @@ public:
   dense128x128 dense128_L3;
   dense128x128 dense128_L4;
 
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
   input_plio  layer0_weights[TP_CASC_LEN_768];
   input_plio  layer1_weights[TP_CASC_LEN_128];
   input_plio  layer2_weights[TP_CASC_LEN_128];
@@ -125,12 +125,12 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_768; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX        + std::to_string(i) + ".txt";
       layer0_in[i] = input_plio::create(("layer0_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#ifdef __AIESIM__
-      std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      layer0_weights[i] = input_plio::create(("layer0_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
-      connect<>(layer0_weights[i].out[0], dense768.inA[i]);
+#if !defined(USE_PRELOADED_WEIGHTS)
+        std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
+        layer0_weights[i] = input_plio::create(("layer0_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
+        connect<>(layer0_weights[i].out[0], dense768.inA[i]);
 #else
-      connect<parameter>(layer0_weights[i], dense768.inA[i]);
+        connect<parameter>(layer0_weights[i], dense768.inA[i]);
 #endif
       connect<>(layer0_in[i].out[0], dense768.inB[i]);
     }
@@ -147,12 +147,12 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_0_PREFIX       + std::to_string(i) + ".txt";
       layer1_in[i] = input_plio::create(("layer1_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#ifdef __AIESIM__
-      std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      layer1_weights[i] = input_plio::create(("layer1_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
-      connect<>(layer1_weights[i].out[0], dense128_L2.inA[i]);
+#if !defined(USE_PRELOADED_WEIGHTS)
+        std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
+        layer1_weights[i] = input_plio::create(("layer1_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
+        connect<>(layer1_weights[i].out[0], dense128_L2.inA[i]);
 #else
-      connect<parameter>(layer1_weights[i], dense128_L2.inA[i]);
+        connect<parameter>(layer1_weights[i], dense128_L2.inA[i]);
 #endif
       connect<>(layer1_in[i].out[0], dense128_L2.inB[i]);
     }
@@ -169,12 +169,12 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_1_PREFIX       + std::to_string(i) + ".txt";
       layer2_in[i] = input_plio::create(("layer2_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#ifdef __AIESIM__
-      std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      layer2_weights[i] = input_plio::create(("layer2_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
-      connect<>(layer2_weights[i].out[0], dense128_L3.inA[i]);
+#if !defined(USE_PRELOADED_WEIGHTS)
+        std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
+        layer2_weights[i] = input_plio::create(("layer2_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
+        connect<>(layer2_weights[i].out[0], dense128_L3.inA[i]);
 #else
-      connect<parameter>(layer2_weights[i], dense128_L3.inA[i]);
+        connect<parameter>(layer2_weights[i], dense128_L3.inA[i]);
 #endif
       connect<>(layer2_in[i].out[0], dense128_L3.inB[i]);
     }
@@ -191,12 +191,12 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_2_PREFIX       + std::to_string(i) + ".txt";
       layer3_in[i] = input_plio::create(("layer3_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#ifdef __AIESIM__
-      std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
-      layer3_weights[i] = input_plio::create(("layer3_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
-      connect<>(layer3_weights[i].out[0], dense128_L4.inA[i]);
+#if !defined(USE_PRELOADED_WEIGHTS)
+        std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
+        layer3_weights[i] = input_plio::create(("layer3_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
+        connect<>(layer3_weights[i].out[0], dense128_L4.inA[i]);
 #else
-      connect<parameter>(layer3_weights[i], dense128_L4.inA[i]);
+        connect<parameter>(layer3_weights[i], dense128_L4.inA[i]);
 #endif
       connect<>(layer3_in[i].out[0], dense128_L4.inB[i]);
     }

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -10,6 +10,7 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
+USE_PRELOADED_WEIGHTS ?= 0
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Default outside the repository when this subdirectory is built directly.
@@ -62,10 +63,14 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
+ifeq ($(USE_PRELOADED_WEIGHTS),1)
+AIE_FLAGS += --define=USE_PRELOADED_WEIGHTS
+endif
+
 
 # ==== RULES ====
 
-.PHONY: all graph sim clean
+.PHONY: all graph sim clean aiesim hw
 
 # --- Default Target ---
 all: graph
@@ -108,4 +113,10 @@ clean:
 	       pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
 	       *.json *.vcd
 	@echo "CLEANED: Build and work directories removed."
+
+aiesim: TARGET=hw
+aiesim: sim
+
+hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: graph
 

--- a/aieml3/README.md
+++ b/aieml3/README.md
@@ -16,20 +16,12 @@ can be changed by setting `DATA_DIR`.
 
 ## Build
 
-From the repository root:
+Use the convenience targets provided in the `Makefile`:
 
-```bash
-cd aieml3
-make graph TARGET=hw       # or TARGET=x86sim
-```
-
-## Simulation
-
-Run cycle‑approximate simulation once the build completes:
-
-```bash
-make sim TARGET=hw        # uses `aiesimulator`
-```
+- `make aiesim` – compile and run simulation with weights loaded from
+  files.
+- `make hw` – build the graph for hardware with the shared DMA weight stream
+  enabled via `USE_PRELOADED_WEIGHTS`.
 
 Results are written next to the input files under `DATA_DIR`.
 

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -4,7 +4,7 @@
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
 #include "nn_defs.h"
-#ifndef __AIESIM__
+#ifdef USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -40,7 +40,7 @@ public:
 
     dense128x27_padded32 dense1;
 
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
     input_plio  layer0_weights;
 #else
     adf::parameter::array<float, OUTPUT_DENSE0_WEIGHTS_SIZE> layer0_weights;
@@ -55,7 +55,7 @@ public:
         layer0_in  = input_plio::create("layer0_in",  plio_32_bits, (base_path + "/" + OUTPUT_INPUT_DATA).c_str());
         layer0_out = output_plio::create("layer0_out", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_OUTPUT).c_str());
 
-#ifdef __AIESIM__
+#if !defined(USE_PRELOADED_WEIGHTS)
         layer0_weights = input_plio::create("layer0_weights", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_WEIGHTS).c_str());
         connect<>(layer0_weights.out[0], dense1.inA[0]);
 #else

--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -13,11 +13,9 @@ stream_connect=mm2s.s:mm2s_switch.S00_AXIS
 
 # Switch outputs to the AIE/PL ports
 stream_connect=mm2s_switch.M00_AXIS:ai_engine_0.layer0_in
-stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.layer0_weights
-stream_connect=mm2s_switch.M02_AXIS:ai_engine_0.layer1_weights_0
-stream_connect=mm2s_switch.M03_AXIS:ai_engine_0.layer1_weights_1
-stream_connect=mm2s_switch.M04_AXIS:relu.bias_stream
-stream_connect=mm2s_switch.M05_AXIS:relu2.bias_stream
+stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.weight_stream
+stream_connect=mm2s_switch.M02_AXIS:relu.bias_stream
+stream_connect=mm2s_switch.M03_AXIS:relu2.bias_stream
 
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
 stream_connect=ai_engine_0.layer0_out:relu.in_stream

--- a/common/linker_aieml2.cfg
+++ b/common/linker_aieml2.cfg
@@ -24,33 +24,12 @@ stream_connect=mm2s_switch.M09_AXIS:ai_engine_0.layer0_in_9
 stream_connect=mm2s_switch.M10_AXIS:ai_engine_0.layer0_in_10
 stream_connect=mm2s_switch.M11_AXIS:ai_engine_0.layer0_in_11
 
-# Layer 0 weights (12-23)
-stream_connect=mm2s_switch.M12_AXIS:ai_engine_0.layer0_weights_0
-stream_connect=mm2s_switch.M13_AXIS:ai_engine_0.layer0_weights_1
-stream_connect=mm2s_switch.M14_AXIS:ai_engine_0.layer0_weights_2
-stream_connect=mm2s_switch.M15_AXIS:ai_engine_0.layer0_weights_3
-stream_connect=mm2s_switch.M16_AXIS:ai_engine_0.layer0_weights_4
-stream_connect=mm2s_switch.M17_AXIS:ai_engine_0.layer0_weights_5
-stream_connect=mm2s_switch.M18_AXIS:ai_engine_0.layer0_weights_6
-stream_connect=mm2s_switch.M19_AXIS:ai_engine_0.layer0_weights_7
-stream_connect=mm2s_switch.M20_AXIS:ai_engine_0.layer0_weights_8
-stream_connect=mm2s_switch.M21_AXIS:ai_engine_0.layer0_weights_9
-stream_connect=mm2s_switch.M22_AXIS:ai_engine_0.layer0_weights_10
-stream_connect=mm2s_switch.M23_AXIS:ai_engine_0.layer0_weights_11
-
-# Layer 1-3 weights (24-29)
-stream_connect=mm2s_switch.M24_AXIS:ai_engine_0.layer1_weights_0
-stream_connect=mm2s_switch.M25_AXIS:ai_engine_0.layer1_weights_1
-stream_connect=mm2s_switch.M26_AXIS:ai_engine_0.layer2_weights_0
-stream_connect=mm2s_switch.M27_AXIS:ai_engine_0.layer2_weights_1
-stream_connect=mm2s_switch.M28_AXIS:ai_engine_0.layer3_weights_0
-stream_connect=mm2s_switch.M29_AXIS:ai_engine_0.layer3_weights_1
-
-# Biases for each layer (30-33)
-stream_connect=mm2s_switch.M30_AXIS:relu0.bias_stream
-stream_connect=mm2s_switch.M31_AXIS:relu1.bias_stream
-stream_connect=mm2s_switch.M32_AXIS:relu2.bias_stream
-stream_connect=mm2s_switch.M33_AXIS:relu3.bias_stream
+# Shared weight stream and biases
+stream_connect=mm2s_switch.M12_AXIS:ai_engine_0.weight_stream
+stream_connect=mm2s_switch.M13_AXIS:relu0.bias_stream
+stream_connect=mm2s_switch.M14_AXIS:relu1.bias_stream
+stream_connect=mm2s_switch.M15_AXIS:relu2.bias_stream
+stream_connect=mm2s_switch.M16_AXIS:relu3.bias_stream
 
 # Existing AIE graph connections
 stream_connect=ai_engine_0.layer0_out:relu0.in_stream

--- a/common/linker_aieml3.cfg
+++ b/common/linker_aieml3.cfg
@@ -8,7 +8,7 @@ nk=axis_switch:1:mm2s_switch
 # --- Stream Connections ---
 stream_connect=mm2s.s:mm2s_switch.S00_AXIS
 stream_connect=mm2s_switch.M00_AXIS:ai_engine_0.layer0_in
-stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.layer0_weights
+stream_connect=mm2s_switch.M01_AXIS:ai_engine_0.weight_stream
 stream_connect=mm2s_switch.M02_AXIS:relu.bias_stream
 
 # AIE output passes through LeakyReLU before being written back to memory


### PR DESCRIPTION
## Summary
- add USE_PRELOADED_WEIGHTS option and `aiesim`/`hw` targets to subgraph makefiles
- switch graph headers to preload weights from a shared DMA stream when the flag is set
- update linker configs and docs for the DMA weight interface

## Testing
- `make -C aieml aiesim` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `make -C aieml2 aiesim` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `make -C aieml3 hw` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a66addcfac8320997fa9dbcd836719