### PR TITLE
Add mm2s PL kernel and integration

### DIFF
--- a/pl/Makefile
+++ b/pl/Makefile
@@ -6,7 +6,7 @@
 VITIS_HLS ?= vitis_hls
 
 # List of kernels (add more as needed)
-KERNELS ?= leaky_relu leaky_splitter s2mm roll_concat
+KERNELS ?= leaky_relu leaky_splitter s2mm roll_concat mm2s
 # KERNELS := roll_concat
 
 

--- a/pl/mm2s_project.tcl
+++ b/pl/mm2s_project.tcl
@@ -1,0 +1,77 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'mm2s'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "mm2s"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "${kernel_name}_pl"
+set kernel_file  "src/${kernel_name}_pl.cpp"
+set tb_file      "src/${kernel_name}_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+# Add your project's specific source files from src/
+add_files $kernel_file
+add_files -tb $tb_file
+add_files -tb ../data/output_data_ref.txt
+
+# Use the -flow_target vitis flag for correct XO generation
+open_solution -flow_target vitis "solution1"
+
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" {
+        puts "### Running C Simulation... ###"
+        csim_design
+    }
+    "csynth" {
+        puts "### Running C Synthesis... ###"
+        csynth_design
+    }
+    "cosim" {
+        puts "### Running Synthesis and Co-simulation... ###"
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        puts "### Running Synthesis and Exporting IP... ###"
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        puts "### Running Synthesis and Exporting XO... ###"
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        puts "### Running Synthesis... ###"
+        csynth_design
+        puts "### Exporting XO and IP Catalog... ###"
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default {
+        puts "ERROR: Unknown command '$command'."
+    }
+}
+
+close_project
+exit

--- a/pl/src/mm2s_pl.cpp
+++ b/pl/src/mm2s_pl.cpp
@@ -1,0 +1,27 @@
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+
+typedef float data_t;
+typedef hls::axis<data_t, 0, 0, 0> axis_t;
+
+extern "C" {
+    // Read elements from memory and write to an AXI stream
+    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size) {
+        #pragma HLS INTERFACE m_axi port=mem offset=slave bundle=gmem depth=128
+        #pragma HLS INTERFACE axis port=s
+        #pragma HLS INTERFACE s_axilite port=mem bundle=control
+        #pragma HLS INTERFACE s_axilite port=offset bundle=control
+        #pragma HLS INTERFACE s_axilite port=size bundle=control
+        #pragma HLS INTERFACE s_axilite port=return bundle=control
+
+        for (int i = 0; i < size; i++) {
+            #pragma HLS PIPELINE II=1
+            axis_t val;
+            val.data = mem[offset + i];
+            val.keep = -1;
+            val.last = (i == size - 1);
+            s.write(val);
+        }
+    }
+}

--- a/pl/src/mm2s_test.cpp
+++ b/pl/src/mm2s_test.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+#include "../../common/data_paths.h"
+
+typedef float data_t;
+typedef hls::axis<data_t, 0, 0, 0> axis_t;
+
+extern "C" void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size);
+
+constexpr int SIZE = 128;
+
+int main() {
+    std::vector<data_t> mem_in(SIZE);
+    std::vector<data_t> golden_data;
+    golden_data.reserve(SIZE);
+
+    std::ifstream fin(std::string(DATA_DIR) + "/output_data_ref.txt");
+    if (!fin.is_open()) {
+        std::cerr << "ERROR: Cannot open input file leakyrelu_output_ref.txt" << std::endl;
+        return 1;
+    }
+
+    for (int i = 0; i < SIZE; ++i) {
+        data_t val;
+        fin >> val;
+        mem_in[i] = val;
+        golden_data.push_back(val);
+    }
+    fin.close();
+
+    hls::stream<axis_t> s_out;
+    mm2s_pl(mem_in.data(), s_out, 0, SIZE);
+
+    bool pass = true;
+    for (int i = 0; i < SIZE; ++i) {
+        axis_t val = s_out.read();
+        if (val.data != golden_data[i]) {
+            std::cerr << "Mismatch @ index " << i << ": Expected " << golden_data[i]
+                      << ", Got " << val.data << std::endl;
+            pass = false;
+        }
+    }
+
+    if (pass)
+        std::cout << "Test PASSED – all " << SIZE << " words streamed correctly." << std::endl;
+    else
+        std::cout << "Test FAILED." << std::endl;
+
+    return pass ? 0 : 1;
+}

--- a/system_project.yaml
+++ b/system_project.yaml
@@ -21,7 +21,7 @@ components:
     type: kernel
     path: pl/build_hw_emu
     kernels:
-      - mm2s_8_128.xo
+      - mm2s_hls.xo
       - s2mm_16_128.xo
       - s2mm_32_128.xo
       - axis_switch.xo


### PR DESCRIPTION
## Summary
- Add memory-mapped-to-stream kernel `mm2s_pl` and testbench
- Provide Vitis HLS project script `mm2s_project.tcl`
- Include new kernel in build system and system project configuration

## Testing
- `make KERNELS=mm2s kernels` *(fails: `vitis_hls: not found`)*
- `make KERNELS=mm2s sim` *(fails: `vitis_hls: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a672ea07c48320b701c7ff810c02b7