### PR TITLE
Add axis switch HLS kernel and integrate build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ LINK_CFG  := ./common/linker_$(GRAPH).cfg
 DATA_DIR  ?= $(abspath ./data)
 
 ifeq ($(GRAPH),aieml3)
-  HLS_KERNELS := leaky_relu s2mm
+  HLS_KERNELS := leaky_relu axis_switch s2mm mm2s
 else
-  HLS_KERNELS := leaky_relu leaky_splitter roll_concat s2mm
+  HLS_KERNELS := leaky_relu leaky_splitter roll_concat axis_switch s2mm mm2s
 endif
 
 POST_BOOT := post_boot.sh

--- a/pl/Makefile
+++ b/pl/Makefile
@@ -6,7 +6,7 @@
 VITIS_HLS ?= vitis_hls
 
 # List of kernels (add more as needed)
-KERNELS ?= leaky_relu leaky_splitter s2mm roll_concat mm2s
+KERNELS ?= leaky_relu leaky_splitter s2mm roll_concat mm2s axis_switch
 # KERNELS := roll_concat
 
 

--- a/pl/axis_switch_project.tcl
+++ b/pl/axis_switch_project.tcl
@@ -1,0 +1,73 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'axis_switch'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "axis_switch"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "${kernel_name}_pl"
+set kernel_file  "src/${kernel_name}_pl.cpp"
+set tb_file      "src/${kernel_name}_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+add_files $kernel_file
+add_files -tb $tb_file
+
+open_solution -flow_target vitis "solution1"
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" {
+        puts "### Running C Simulation... ###"
+        csim_design
+    }
+    "csynth" {
+        puts "### Running C Synthesis... ###"
+        csynth_design
+    }
+    "cosim" {
+        puts "### Running Synthesis and Co-simulation... ###"
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        puts "### Running Synthesis and Exporting IP... ###"
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        puts "### Running Synthesis and Exporting XO... ###"
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        puts "### Running Synthesis... ###"
+        csynth_design
+        puts "### Exporting XO and IP Catalog... ###"
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default {
+        puts "ERROR: Unknown command '$command'."
+    }
+}
+
+close_project
+exit

--- a/pl/src/axis_switch_pl.cpp
+++ b/pl/src/axis_switch_pl.cpp
@@ -1,0 +1,28 @@
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+
+static const int NUM_OUTPUTS = 17;
+
+typedef float data_t;
+typedef hls::axis<data_t, 0, 5, 0> axis_t; // DEST width 5 bits
+
+extern "C" {
+void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS]) {
+#pragma HLS INTERFACE axis port=in
+#pragma HLS INTERFACE axis port=out
+#pragma HLS INTERFACE s_axilite port=return bundle=control
+#pragma HLS ARRAY_PARTITION variable=out complete
+
+    bool last = false;
+    while (!last) {
+#pragma HLS PIPELINE II=1
+        axis_t val = in.read();
+        ap_uint<5> dest = val.dest;
+        if (dest < NUM_OUTPUTS) {
+            out[dest].write(val);
+        }
+        last = val.last;
+    }
+}
+}

--- a/pl/src/axis_switch_test.cpp
+++ b/pl/src/axis_switch_test.cpp
@@ -1,0 +1,39 @@
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+#include <iostream>
+
+static const int NUM_OUTPUTS = 17;
+
+typedef float data_t;
+typedef hls::axis<data_t, 0, 5, 0> axis_t;
+
+extern "C" void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS]);
+
+int main() {
+    hls::stream<axis_t> in;
+    hls::stream<axis_t> out[NUM_OUTPUTS];
+
+    const int NUM = 34;
+    // Generate input data with varying destinations
+    for (int i = 0; i < NUM; ++i) {
+        axis_t val;
+        val.data = i;
+        val.keep = -1;
+        val.dest = i % NUM_OUTPUTS;
+        val.last = (i == NUM - 1);
+        in.write(val);
+    }
+
+    axis_switch_pl(in, out);
+
+    // Verify that each output received the correct element
+    for (int i = 0; i < NUM; ++i) {
+        axis_t v = out[i % NUM_OUTPUTS].read();
+        if (v.data != i) {
+            std::cerr << "Mismatch at index " << i << std::endl;
+            return 1;
+        }
+    }
+    std::cout << "Testbench completed successfully." << std::endl;
+    return 0;
+}

--- a/system_project.yaml
+++ b/system_project.yaml
@@ -19,12 +19,14 @@ components:
 
   - name: pl_kernels
     type: kernel
-    path: pl/build_hw_emu
+    path: pl/ip
     kernels:
+      - leaky_relu_hls.xo
+      - leaky_splitter_hls.xo
+      - roll_concat_hls.xo
+      - s2mm_hls.xo
       - mm2s_hls.xo
-      - s2mm_16_128.xo
-      - s2mm_32_128.xo
-      - axis_switch.xo
+      - axis_switch_hls.xo
 
   - name: hw_link_output
     type: xsa


### PR DESCRIPTION
## Summary
- Implement `axis_switch_pl` kernel supporting 17 output AXI streams
- Add Vitis HLS project script for axis switch
- Integrate axis switch and mm2s in Makefiles and system configuration

## Testing
- `make -C pl TARGET=sw_emu KERNELS="axis_switch mm2s"` *(fails: vitis_hls: not found)*
- `TARGET=sw_emu GRAPH=aieml make all` *(fails: DSPLIB_PATH not found)*
- `TARGET=sw_emu GRAPH=aieml2 make all` *(fails: DSPLIB_PATH not found)*
- `TARGET=sw_emu GRAPH=aieml3 make all` *(fails: DSPLIB_PATH not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6771a091083208061d3f61fccb4a7