### PR TITLE
Align kernel paths in system project

### DIFF
--- a/system_project.yaml
+++ b/system_project.yaml
@@ -19,11 +19,9 @@ components:
 
   - name: pl_kernels
     type: kernel
-    path: pl/ip
+    path: pl/ip/
     kernels:
       - leaky_relu_hls.xo
-      - leaky_splitter_hls.xo
-      - roll_concat_hls.xo
       - s2mm_hls.xo
       - mm2s_hls.xo
       - axis_switch_hls.xo


### PR DESCRIPTION
## Summary
- point PL kernel component to `pl/ip/`
- list only generated PL kernel XO files

## Testing
- `make package TARGET=hw_emu` *(fails: Directory not found '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68a67945ef8c8320851754b54530f5b9