### PR TITLE
Use PL axis switch in linker configs

### DIFF
--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -5,7 +5,7 @@ nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
 nk=s2mm_pl:1:s2mm_out
-nk=axis_switch:1:mm2s_switch
+nk=axis_switch_pl:1:mm2s_switch
 
 # --- Stream Connections ---
 # mm2s -> AXI4-Stream switch

--- a/common/linker_aieml2.cfg
+++ b/common/linker_aieml2.cfg
@@ -5,7 +5,7 @@ nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:4:relu0,relu1,relu2,relu3
 nk=leaky_splitter_pl:3:split0,split1,split2
 nk=s2mm_pl:1:s2mm_out
-nk=axis_switch:1:mm2s_switch
+nk=axis_switch_pl:1:mm2s_switch
 
 # --- Stream Connections ---
 stream_connect=mm2s.s:mm2s_switch.S00_AXIS

--- a/common/linker_aieml3.cfg
+++ b/common/linker_aieml3.cfg
@@ -3,7 +3,7 @@
 nk=mm2s_pl:1:mm2s
 nk=leaky_relu_pl:1:relu
 nk=s2mm_pl:1:s2mm_out
-nk=axis_switch:1:mm2s_switch
+nk=axis_switch_pl:1:mm2s_switch
 
 # --- Stream Connections ---
 stream_connect=mm2s.s:mm2s_switch.S00_AXIS


### PR DESCRIPTION
## Summary
- Point AI Engine linker configs to `axis_switch_pl` kernel

## Testing
- `make link` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68a7d35b51f8832096141539d20ebc95