### PR TITLE
Add dest support to mm2s kernel

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -191,6 +191,7 @@ int main(int argc, char** argv) {
             run.set_arg(0, mm2s_bos[i]);
             run.set_arg(2, 0);                    // offset within the buffer
             run.set_arg(3, cfg.mm2s[i].size);     // transfer length
+            run.set_arg(4, 0);                    // AXI stream destination
             run.start();
             run.wait();
         }

--- a/pl/src/mm2s_pl.cpp
+++ b/pl/src/mm2s_pl.cpp
@@ -3,16 +3,17 @@
 #include <ap_axi_sdata.h>
 
 typedef float data_t;
-typedef hls::axis<data_t, 0, 0, 0> axis_t;
+typedef hls::axis<data_t, 0, 0, 5> axis_t;
 
 extern "C" {
     // Read elements from memory and write to an AXI stream
-    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size) {
+    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size, int dest) {
         #pragma HLS INTERFACE m_axi port=mem offset=slave bundle=gmem depth=128
         #pragma HLS INTERFACE axis port=s
         #pragma HLS INTERFACE s_axilite port=mem bundle=control
         #pragma HLS INTERFACE s_axilite port=offset bundle=control
         #pragma HLS INTERFACE s_axilite port=size bundle=control
+        #pragma HLS INTERFACE s_axilite port=dest bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
         for (int i = 0; i < size; i++) {
@@ -21,6 +22,7 @@ extern "C" {
             val.data = mem[offset + i];
             val.keep = -1;
             val.last = (i == size - 1);
+            val.dest = dest;
             s.write(val);
         }
     }

--- a/pl/src/mm2s_test.cpp
+++ b/pl/src/mm2s_test.cpp
@@ -6,9 +6,9 @@
 #include "../../common/data_paths.h"
 
 typedef float data_t;
-typedef hls::axis<data_t, 0, 0, 0> axis_t;
+typedef hls::axis<data_t, 0, 0, 5> axis_t;
 
-extern "C" void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size);
+extern "C" void mm2s_pl(float* mem, hls::stream<axis_t>& s, int offset, int size, int dest);
 
 constexpr int SIZE = 128;
 
@@ -32,7 +32,7 @@ int main() {
     fin.close();
 
     hls::stream<axis_t> s_out;
-    mm2s_pl(mem_in.data(), s_out, 0, SIZE);
+    mm2s_pl(mem_in.data(), s_out, 0, SIZE, 0);
 
     bool pass = true;
     for (int i = 0; i < SIZE; ++i) {


### PR DESCRIPTION
## Summary
- add 5-bit `dest` field to mm2s AXI stream type
- expose new `dest` AXI-Lite argument and set field during transfers
- update host and test code for new mm2s interface

## Testing
- `g++ -I./pl/src -I./common -std=c++17 pl/src/mm2s_pl.cpp pl/src/mm2s_test.cpp -o mm2s_test` *(fails: ap_int.h: No such file or directory)*
- `g++ -std=c++17 host/host.cpp -o host_app` *(fails: experimental/xrt_kernel.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d3fc705483208d45f7e28511f419