### PR TITLE
Fix axis test DEST width

### DIFF
--- a/pl/src/axis_switch_test.cpp
+++ b/pl/src/axis_switch_test.cpp
@@ -5,7 +5,7 @@
 static const int NUM_OUTPUTS = 17;
 
 typedef float data_t;
-typedef hls::axis<data_t, 0, 5, 0> axis_t;
+typedef hls::axis<data_t, 0, 0, 5> axis_t;
 
 extern "C" void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS]);
 


### PR DESCRIPTION
## Summary
- provide 5-bit DEST field in `axis_switch_test` typedef to correctly represent DEST field

## Testing
- `make sim TARGET=csim KERNELS=axis_switch` *(fails: vitis_hls not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a89d0201508320a9527716962245c6