### PR TITLE
Refactor axis switch to explicit output dispatch

### DIFF
--- a/pl/src/axis_switch_pl.cpp
+++ b/pl/src/axis_switch_pl.cpp
@@ -20,7 +20,61 @@ void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS
         axis_t val = in.read();
         ap_uint<5> dest = val.dest;
         if (dest < NUM_OUTPUTS) {
-            out[dest].write(val);
+            switch (dest) {
+            case 0:
+                out[0].write(val);
+                break;
+            case 1:
+                out[1].write(val);
+                break;
+            case 2:
+                out[2].write(val);
+                break;
+            case 3:
+                out[3].write(val);
+                break;
+            case 4:
+                out[4].write(val);
+                break;
+            case 5:
+                out[5].write(val);
+                break;
+            case 6:
+                out[6].write(val);
+                break;
+            case 7:
+                out[7].write(val);
+                break;
+            case 8:
+                out[8].write(val);
+                break;
+            case 9:
+                out[9].write(val);
+                break;
+            case 10:
+                out[10].write(val);
+                break;
+            case 11:
+                out[11].write(val);
+                break;
+            case 12:
+                out[12].write(val);
+                break;
+            case 13:
+                out[13].write(val);
+                break;
+            case 14:
+                out[14].write(val);
+                break;
+            case 15:
+                out[15].write(val);
+                break;
+            case 16:
+                out[16].write(val);
+                break;
+            default:
+                break;
+            }
         }
         last = val.last;
     }


### PR DESCRIPTION
## Summary
- replace dynamic array indexing in `axis_switch_pl.cpp` with explicit `switch` to select among 17 outputs

## Testing
- `cd pl && make kernels KERNELS=axis_switch` *(fails: `vitis_hls: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ddf3f2083209d7e6d2cce19b585