### PR TITLE
Add loop tripcount pragma for axis switch

### DIFF
--- a/pl/src/axis_switch_pl.cpp
+++ b/pl/src/axis_switch_pl.cpp
@@ -15,6 +15,7 @@ void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS
 #pragma HLS ARRAY_PARTITION variable=out complete
 
     bool last = false;
+    #pragma HLS loop_tripcount min=1 max=128
     while (!last) {
 #pragma HLS PIPELINE II=1
         axis_t val = in.read();


### PR DESCRIPTION
## Summary
- Provide explicit loop tripcount for axis switch stream loop

## Testing
- `make kernels KERNELS=axis_switch VITIS_HLS=vitis_hls` *(fails: `vitis_hls: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68a89e73eed48320b9d6916ea9d81286