### PR TITLE
Initialize AI Engine weights before run

### DIFF
--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -109,4 +109,11 @@ public:
                                          (base_path + "/" + EMBED_DENSE1_OUTPUT).c_str());
         connect<>(dense2.out[0], layer1_out.in[0]);
     }
+
+    void init() {
+        graph::init();
+#ifdef USE_PRELOADED_WEIGHTS
+        init_weights();
+#endif
+    }
 };

--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -204,4 +204,12 @@ public:
                                      (base_path + "/" + SUBSOLVER0_DENSE3_OUTPUT).c_str());
     connect<>(dense128_L4.out[0], layer3_out.in[0]);
   }
+
+  void init() {
+    graph::init();
+#ifdef USE_PRELOADED_WEIGHTS
+    init_weights();
+#endif
+  }
 };
+

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -64,4 +64,12 @@ public:
         connect<>(layer0_in.out[0], dense1.inB[0]);
         connect<>(dense1.out[0], layer0_out.in[0]);
     }
+
+    void init() {
+        graph::init();
+#ifdef USE_PRELOADED_WEIGHTS
+        init_weights();
+#endif
+    }
 };
+

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -189,7 +189,8 @@ int main(int argc, char** argv) {
         auto switch_run = xrt::run(axis_switch_kernel);
         switch_run.start();
 
-        // Run AIE graph
+        // Initialize and run AIE graph before starting MM2S transfers
+        aie_graph.init();
         aie_graph.run(1);
 
         // Start producers sequentially, reprogramming the mm2s kernel for each


### PR DESCRIPTION
## Summary
- Override each `NeuralNetworkGraph::init()` to call `init_weights()` ensuring parameter arrays load from the weight stream
- Invoke `aie_graph.init()` on the host prior to launching MM2S transfers so the AI Engine can populate parameters

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a63b1a2c8320a5294439c4dab9d4