### PR TITLE
Add host-driven iteration count for AXI switch

### DIFF
--- a/pl/src/axis_switch_test.cpp
+++ b/pl/src/axis_switch_test.cpp
@@ -7,7 +7,9 @@ static const int NUM_OUTPUTS = 17;
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 5> axis_t;
 
-extern "C" void axis_switch_pl(hls::stream<axis_t> &in, hls::stream<axis_t> out[NUM_OUTPUTS]);
+extern "C" void axis_switch_pl(hls::stream<axis_t> &in,
+                                hls::stream<axis_t> out[NUM_OUTPUTS],
+                                unsigned int total);
 
 int main() {
     hls::stream<axis_t> in;
@@ -24,7 +26,8 @@ int main() {
         in.write(val);
     }
 
-    axis_switch_pl(in, out);
+    // Invoke with an explicit element count
+    axis_switch_pl(in, out, NUM);
 
     // Verify that each output received the correct element
     for (int i = 0; i < NUM; ++i) {


### PR DESCRIPTION
## Summary
- Extend AXI switch kernel to accept a host-provided element count
- Sum MM2S transfer sizes and pass count to switch kernel from host
- Update testbench for new kernel interface

## Testing
- ❌ `g++ -std=c++17 pl/src/axis_switch_pl.cpp pl/src/axis_switch_test.cpp -I/workspace/rtda_demo/pl/src -o axis_switch_test` (missing Xilinx HLS headers)
- ❌ `g++ -std=c++17 host/host.cpp -c` (missing XRT headers)


------
https://chatgpt.com/codex/tasks/task_e_68a8a7392c2c8320b55c4cbc97d05536