### PR TITLE
Buffer bias vector in leaky_relu kernel

### DIFF
--- a/pl/src/leaky_relu_pl.cpp
+++ b/pl/src/leaky_relu_pl.cpp
@@ -18,11 +18,23 @@ extern "C" {
         #pragma HLS INTERFACE s_axilite port=size bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-        for (int i = 0; i < size; i++) {
+        // Buffer all bias values first so input processing is never stalled
+        data_t bias_buffer[HIDDEN_SIZE];
+        // Ensure the compiler keeps accesses to this buffer on-chip
+        #pragma HLS BIND_STORAGE variable=bias_buffer type=ram_1p impl=bram
+
+        // Read in the entire bias vector
+        bias_read: for (int i = 0; i < size; i++) {
             #pragma HLS pipeline II=1
-            axis_t val       = in_stream.read();
-            axis_t bias_val  = bias_stream.read();
-            data_t input_val = val.data + bias_val.data;
+            axis_t bias_val = bias_stream.read();
+            bias_buffer[i] = bias_val.data;
+        }
+
+        // Process activations using the buffered biases
+        relu_loop: for (int i = 0; i < size; i++) {
+            #pragma HLS pipeline II=1
+            axis_t val = in_stream.read();
+            data_t input_val = val.data + bias_buffer[i];
             data_t output_val = (input_val >= 0) ? input_val : (input_val * LEAKY_SLOPE);
             val.data = output_val;
             out_stream.write(val);


### PR DESCRIPTION
## Summary
- Buffer full bias vector locally in `leaky_relu_pl` to avoid activation stall when bias arrives late

## Testing
- `make sim TARGET=csim KERNELS=leaky_relu` *(fails: `vitis_hls` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a895a4a48320997f79ac5bbfed8d