### PR TITLE
Add CLI graph selection for host

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -31,7 +31,7 @@ make SYSROOT=/path/to/sysroot
 Ensure the cross-compiler (`aarch64-linux-gnu-g++`) and XRT development files are available in the environment.
 
 ## Runtime
-Run the executable on a Versal device running PetaLinux with XRT support.  Select which graph to drive using `--graph` (defaults to `aieml`):
+Run the executable on a Versal device running PetaLinux with XRT support.  Choose the graph at runtime with `--graph=<aieml|aieml2|aieml3>` (defaults to `aieml`):
 
 ```bash
 ./system_host a.xclbin --graph=aieml2

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -10,10 +10,6 @@
 #include "data_paths.h"
 #include "nn_defs.h"
 
-// ------ Set this to "aieml", "aieml2", or "aieml3" ------
-static constexpr const char* kGraphName = "aieml3";
-// ---------------------------------------------------------
-
 // Load text files containing floats into a vector
 static std::vector<float> read_file_to_vector(const std::string& filename, int size) {
     std::vector<float> data;
@@ -127,15 +123,28 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
 
 int main(int argc, char** argv) {
     if (argc < 2) {
-        std::cout << "Usage: " << argv[0] << " <a.xclbin>\n";
+        std::cout << "Usage: " << argv[0]
+                  << " <a.xclbin> [--graph=<aieml|aieml2|aieml3>]\n";
         return 1;
     }
 
     const std::string xclbinFilename = argv[1];
     const std::string base_path = "./data";
+    std::string graph_name = "aieml"; // default graph
 
-    // Use the single variable above instead of a command-line option
-    GraphConfig cfg = make_config(kGraphName, base_path);
+    for (int i = 2; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg.rfind("--graph=", 0) == 0) {
+            graph_name = arg.substr(8);
+        } else {
+            std::cerr << "Unknown option: " << arg << "\n";
+            std::cout << "Usage: " << argv[0]
+                      << " <a.xclbin> [--graph=<aieml|aieml2|aieml3>]\n";
+            return 1;
+        }
+    }
+
+    GraphConfig cfg = make_config(graph_name, base_path);
 
     try {
         xrt::device device(0);

--- a/post_boot.sh
+++ b/post_boot.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export XILINX_XRT=/usr
+./system_host system_hw.xclbin --graph=aieml
+


### PR DESCRIPTION
## Summary
- allow selecting graph at runtime with `--graph=<name>` and remove hard-coded constant
- update post_boot.sh to pass graph argument to host
- document the new `--graph` option in host README

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a9574a188320b70abfba2c6ab987