### PR TITLE
Remove redundant AIE graph initialization

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -202,8 +202,7 @@ int main(int argc, char** argv) {
         switch_run.set_arg(18, switch_total);
         switch_run.start();
 
-        // Initialize and run AIE graph before starting MM2S transfers
-        aie_graph.init();
+        // Run AIE graph before starting MM2S transfers
         aie_graph.run(1);
 
         // Start producers sequentially, reprogramming the mm2s kernel for each


### PR DESCRIPTION
## Summary
- Launch AIE graph solely using `aie_graph.run` without prior `init`
- Update comment to reflect streamlined graph start

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8acd32dc4832086ab4468ea3b1436