### PR TITLE
Move USE_PRELOADED_WEIGHTS toggle into nn_defs.h

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -10,7 +10,6 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
-USE_PRELOADED_WEIGHTS ?= 1
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Defaults two levels up so data lives outside the source tree when building
@@ -64,9 +63,6 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
-ifeq ($(USE_PRELOADED_WEIGHTS),1)
-AIE_FLAGS += --cflags=-DUSE_PRELOADED_WEIGHTS
-endif
 
 
 # ==== RULES ====
@@ -118,6 +114,6 @@ clean:
 aiesim: TARGET=hw
 aiesim: sim
 
-hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: TARGET=hw
 hw: graph
 

--- a/aieml/README.md
+++ b/aieml/README.md
@@ -23,9 +23,8 @@ The `Makefile` provides two convenience targets:
 
 - `make aiesim` – compile and run cycle-accurate simulation using file-based
   weights.
-- `make hw` – build the graph for hardware. This defines the
-  `USE_PRELOADED_WEIGHTS` flag so weights are delivered through the shared DMA
-  stream.
+- `make hw` – build the graph for hardware. Set `USE_PRELOADED_WEIGHTS` to 1 in
+  `common/nn_defs.h` to deliver weights through the shared DMA stream.
 
 Both commands produce `Work/libadf.a` inside this directory. To invoke the
 compiler directly without the wrapper:

--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -4,7 +4,7 @@
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -54,7 +54,7 @@ public:
     input_plio  layer1_in[TP_CASC_LEN_LAYER2];
     output_plio layer1_out;
 
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
     input_plio  layer0_weights;
     input_plio  layer1_weights[TP_CASC_LEN_LAYER2];
 #else
@@ -80,7 +80,7 @@ public:
         layer0_out = output_plio::create("layer0_out", plio_32_bits,
                                         (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
 
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         layer0_weights = input_plio::create("layer0_weights", plio_32_bits,
                                             (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
         connect<>(layer0_weights.out[0], dense1.inA[0]);
@@ -94,7 +94,7 @@ public:
             std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
             std::string in_name = "layer1_in_" + std::to_string(i);
             layer1_in[i] = input_plio::create(in_name.c_str(), plio_32_bits, in_file.c_str());
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
             std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
             std::string w_name  = "layer1_weights_" + std::to_string(i);
             layer1_weights[i] = input_plio::create(w_name.c_str(), plio_32_bits, w_file.c_str());
@@ -112,7 +112,7 @@ public:
 
     void init() {
         graph::init();
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
         init_weights();
 #endif
     }

--- a/aieml2/Makefile
+++ b/aieml2/Makefile
@@ -10,7 +10,6 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
-USE_PRELOADED_WEIGHTS ?= 0
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Default outside the repository when this subdirectory is built directly.
@@ -63,9 +62,6 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
-ifeq ($(USE_PRELOADED_WEIGHTS),1)
-AIE_FLAGS += --cflags=-DUSE_PRELOADED_WEIGHTS
-endif
 
 
 # ==== RULES ====
@@ -117,6 +113,6 @@ clean:
 aiesim: TARGET=hw
 aiesim: sim
 
-hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: TARGET=hw
 hw: graph
 

--- a/aieml2/README.md
+++ b/aieml2/README.md
@@ -19,8 +19,8 @@ those files to be overridden with the `DATA_DIR` environment variable.
 Two wrapper targets are provided:
 
 - `make aiesim` – compile and simulate the graph with file-based weights.
-- `make hw` – build for hardware. This enables the `USE_PRELOADED_WEIGHTS`
-  macro so that weights are supplied by a shared DMA stream.
+- `make hw` – build for hardware. Set `USE_PRELOADED_WEIGHTS` to 1 in
+  `common/nn_defs.h` so that weights are supplied by a shared DMA stream.
 
 Both commands write the compiled artefacts to `Work/`. Simulation reads all
 inputs from `DATA_DIR` and writes layer outputs back to the same location.

--- a/aieml2/graph.h
+++ b/aieml2/graph.h
@@ -4,7 +4,7 @@
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
 #include "nn_defs.h"
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -88,7 +88,7 @@ public:
   dense128x128 dense128_L3;
   dense128x128 dense128_L4;
 
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
   input_plio  layer0_weights[TP_CASC_LEN_768];
   input_plio  layer1_weights[TP_CASC_LEN_128];
   input_plio  layer2_weights[TP_CASC_LEN_128];
@@ -125,7 +125,7 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_768; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX        + std::to_string(i) + ".txt";
       layer0_in[i] = input_plio::create(("layer0_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
         layer0_weights[i] = input_plio::create(("layer0_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
         connect<>(layer0_weights[i].out[0], dense768.inA[i]);
@@ -147,7 +147,7 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_0_PREFIX       + std::to_string(i) + ".txt";
       layer1_in[i] = input_plio::create(("layer1_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
         layer1_weights[i] = input_plio::create(("layer1_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
         connect<>(layer1_weights[i].out[0], dense128_L2.inA[i]);
@@ -169,7 +169,7 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_1_PREFIX       + std::to_string(i) + ".txt";
       layer2_in[i] = input_plio::create(("layer2_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
         layer2_weights[i] = input_plio::create(("layer2_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
         connect<>(layer2_weights[i].out[0], dense128_L3.inA[i]);
@@ -191,7 +191,7 @@ public:
     for (int i = 0; i < (int)TP_CASC_LEN_128; ++i) {
       std::string in_file = base_path + "/" + SUBSOLVER0_LEAKYRELU_2_PREFIX       + std::to_string(i) + ".txt";
       layer3_in[i] = input_plio::create(("layer3_in_" + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str());
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         std::string w_file  = base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX    + std::to_string(i) + ".txt";
         layer3_weights[i] = input_plio::create(("layer3_weights_" + std::to_string(i)).c_str(), plio_32_bits, w_file.c_str());
         connect<>(layer3_weights[i].out[0], dense128_L4.inA[i]);
@@ -207,7 +207,7 @@ public:
 
   void init() {
     graph::init();
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
     init_weights();
 #endif
   }

--- a/aieml3/Makefile
+++ b/aieml3/Makefile
@@ -10,7 +10,6 @@ PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202
 
 # Target for compilation and simulation. Options: x86sim, hw
 TARGET       ?= hw
-USE_PRELOADED_WEIGHTS ?= 0
 
 # Location of input/weight files used by PLIO connections (override from top-level)
 # Default outside the repository when this subdirectory is built directly.
@@ -63,9 +62,6 @@ AIE_FLAGS := \
         --pl-freq=$(PL_FREQ_MHZ) \
         $(AIE_INCLUDE_FLAGS)
 
-ifeq ($(USE_PRELOADED_WEIGHTS),1)
-AIE_FLAGS += --cflags=-DUSE_PRELOADED_WEIGHTS
-endif
 
 
 # ==== RULES ====
@@ -117,6 +113,6 @@ clean:
 aiesim: TARGET=hw
 aiesim: sim
 
-hw: TARGET=hw USE_PRELOADED_WEIGHTS=1
+hw: TARGET=hw
 hw: graph
 

--- a/aieml3/README.md
+++ b/aieml3/README.md
@@ -20,8 +20,8 @@ Use the convenience targets provided in the `Makefile`:
 
 - `make aiesim` – compile and run simulation with weights loaded from
   files.
-- `make hw` – build the graph for hardware with the shared DMA weight stream
-  enabled via `USE_PRELOADED_WEIGHTS`.
+- `make hw` – build the graph for hardware. Set `USE_PRELOADED_WEIGHTS` to 1 in
+  `common/nn_defs.h` to enable the shared DMA weight stream.
 
 Results are written next to the input files under `DATA_DIR`.
 

--- a/aieml3/graph.h
+++ b/aieml3/graph.h
@@ -4,7 +4,7 @@
 #include "matrix_vector_mul_graph.hpp"
 #include "aie_api/aie_adf.hpp"
 #include "nn_defs.h"
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
 #include <array>
 #endif
 
@@ -40,7 +40,7 @@ public:
 
     dense128x27_padded32 dense1;
 
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
     input_plio  layer0_weights;
 #else
     adf::parameter::array<float, OUTPUT_DENSE0_WEIGHTS_SIZE> layer0_weights;
@@ -55,7 +55,7 @@ public:
         layer0_in  = input_plio::create("layer0_in",  plio_32_bits, (base_path + "/" + OUTPUT_INPUT_DATA).c_str());
         layer0_out = output_plio::create("layer0_out", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_OUTPUT).c_str());
 
-#if !defined(USE_PRELOADED_WEIGHTS)
+#if !USE_PRELOADED_WEIGHTS
         layer0_weights = input_plio::create("layer0_weights", plio_32_bits, (base_path + "/" + OUTPUT_DENSE0_WEIGHTS).c_str());
         connect<>(layer0_weights.out[0], dense1.inA[0]);
 #else
@@ -67,7 +67,7 @@ public:
 
     void init() {
         graph::init();
-#ifdef USE_PRELOADED_WEIGHTS
+#if USE_PRELOADED_WEIGHTS
         init_weights();
 #endif
     }

--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -13,7 +13,7 @@ stream_connect=mm2s.s:mm2s_switch.in
 
 # Switch outputs to the AIE/PL ports
 stream_connect=mm2s_switch.out_0:ai_engine_0.layer0_in
-stream_connect=mm2s_switch.out_1:ai_engine_0.weight_stream  # Enable with USE_PRELOADED_WEIGHTS=1
+stream_connect=mm2s_switch.out_1:ai_engine_0.weight_stream  # Enable when USE_PRELOADED_WEIGHTS=1
 stream_connect=mm2s_switch.out_2:relu.bias_stream
 stream_connect=mm2s_switch.out_3:relu2.bias_stream
 

--- a/common/nn_defs.h
+++ b/common/nn_defs.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// Toggle between runtime-loaded and preloaded weights. Set to 1 to embed
+// weights into the graph at compile time or 0 to load them from files.
+#define USE_PRELOADED_WEIGHTS 0
+
 constexpr int INPUT_SIZE = 8;
 constexpr int HIDDEN_SIZE = 128;
 constexpr int OUTPUT_SIZE = 128;


### PR DESCRIPTION
## Summary
- Define `USE_PRELOADED_WEIGHTS` in `common/nn_defs.h` so it can be toggled manually
- Remove Makefile compiler flag and update graph headers to use the new macro
- Refresh documentation to describe the new weight-loading configuration

## Testing
- `make graph` (fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')

------
https://chatgpt.com/codex/tasks/task_e_68a8b8418cdc8320b974f4d2e5cfecf0