### PR TITLE
Remove roll_concat kernel from non-aieml3 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ DATA_DIR  ?= $(abspath ./data)
 ifeq ($(GRAPH),aieml3)
   HLS_KERNELS := mm2s leaky_relu s2mm
 else
-  HLS_KERNELS := mm2s leaky_relu leaky_splitter roll_concat s2mm
+  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
 endif
 
 POST_BOOT := post_boot.sh


### PR DESCRIPTION
## Summary
- drop `roll_concat` from HLS kernels when building graphs other than `aieml3`

## Testing
- `make aieml` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `GRAPH=aieml make aieml -n | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68ab1bee4b9c83209fc1c904b8d48013