### PR TITLE
Add roll_concat kernel to aieml linker

### DIFF
--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -6,6 +6,7 @@ nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,m
 
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
+nk=roll_concat_pl:1:roll_concat
 nk=s2mm_pl:1:s2mm_out
 
 # --- Stream Connections ---
@@ -28,8 +29,10 @@ stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
 
 stream_connect=mm2s_bias2.s:relu2.bias_stream
 
-# Final output from the AIE graph passes through a second LeakyReLU before being written to memory
-stream_connect=ai_engine_0.layer1_out:relu2.in_stream
+# Final output from the AIE graph is roll-concatenated, processed by a second
+# LeakyReLU, then written to memory
+stream_connect=ai_engine_0.layer1_out:roll_concat.in
+stream_connect=roll_concat.out:relu2.in_stream
 stream_connect=relu2.out_stream:s2mm_out.s
 
 


### PR DESCRIPTION
## Summary
- Instantiate roll_concat_pl compute unit in `linker_aieml.cfg`
- Connect roll_concat kernel between AI Engine output and final LeakyReLU

## Testing
- `make GRAPH=aieml` *(fails: Directory not found for Vitis DSP Library)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1c8acd248320900b0400e954fb85