### PR TITLE
Remove roll_concat PL stage and expose AIEML outputs

### DIFF
--- a/aieml/graph.h
+++ b/aieml/graph.h
@@ -44,6 +44,7 @@ class NeuralNetworkGraph : public graph {
 public:
     input_plio  layer0_in;
     input_plio  layer0_weights;
+    // Output of first dense layer exposed via PLIO for direct PL interfacing
     output_plio layer0_out;
 
     dense8x128   dense1;
@@ -51,6 +52,7 @@ public:
 
     input_plio  layer1_in[TP_CASC_LEN_LAYER2];
     input_plio  layer1_weights[TP_CASC_LEN_LAYER2];
+    // Final dense layer output directly drives a PLIO
     output_plio layer1_out;
 
     NeuralNetworkGraph() {

--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -6,7 +6,7 @@ nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,m
 
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
-nk=roll_concat_pl:1:roll_concat
+# nk=roll_concat_pl:1:roll_concat  # removed: outputs now routed directly
 nk=s2mm_pl:1:s2mm_out
 
 # --- Stream Connections ---
@@ -29,10 +29,9 @@ stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
 
 stream_connect=mm2s_bias2.s:relu2.bias_stream
 
-# Final output from the AIE graph is roll-concatenated, processed by a second
-# LeakyReLU, then written to memory
-stream_connect=ai_engine_0.layer1_out:roll_concat.in
-stream_connect=roll_concat.out:relu2.in_stream
+# Final output from the AIE graph is processed by a second LeakyReLU and
+# written to memory (roll_concat removed)
+stream_connect=ai_engine_0.layer1_out:relu2.in_stream
 stream_connect=relu2.out_stream:s2mm_out.s
 
 

--- a/pl/Makefile
+++ b/pl/Makefile
@@ -6,8 +6,8 @@
 VITIS_HLS ?= vitis_hls
 
 # List of kernels (add more as needed)
-KERNELS ?= mm2s leaky_relu leaky_splitter s2mm roll_concat
-# KERNELS := roll_concat
+KERNELS ?= mm2s leaky_relu leaky_splitter s2mm
+# KERNELS :=
 
 
 IP_DIR   ?= ip


### PR DESCRIPTION
## Summary
- expose dense layer outputs through PLIO ports in the aieml graph
- drop roll_concat kernel and connect aieml output directly to the second LeakyReLU
- stop building roll_concat in PL makefile

## Testing
- `make -C aieml graph TARGET=x86sim` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68ab20d62eac83208ce0b2be0f472fbe