### PR TITLE
Preload bias data into BRAM buffer

### DIFF
--- a/pl/src/leaky_relu_pl.cpp
+++ b/pl/src/leaky_relu_pl.cpp
@@ -18,11 +18,19 @@ extern "C" {
         #pragma HLS INTERFACE s_axilite port=size bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-        for (int i = 0; i < size; i++) {
+        data_t bias_buf[HIDDEN_SIZE];
+        #pragma HLS BIND_STORAGE variable=bias_buf type=ram_1p impl=bram
+
+        preload_loop: for (int i = 0; i < size; i++) {
+            #pragma HLS PIPELINE II=1
+            axis_t bias_val = bias_stream.read();
+            bias_buf[i] = bias_val.data;
+        }
+
+        main_loop: for (int i = 0; i < size; i++) {
             #pragma HLS pipeline II=1
-            axis_t val       = in_stream.read();
-            axis_t bias_val  = bias_stream.read();
-            data_t input_val = val.data + bias_val.data;
+            axis_t val = in_stream.read();
+            data_t input_val = val.data + bias_buf[i];
             data_t output_val = (input_val >= 0) ? input_val : (input_val * LEAKY_SLOPE);
             val.data = output_val;
             out_stream.write(val);


### PR DESCRIPTION
## Summary
- Add BRAM-bound bias buffer and preload loop in `leaky_relu_pl`
- Use buffered bias values inside main processing loop

## Testing
- `g++ -std=c++17 pl/src/leaky_relu_pl.cpp pl/src/leaky_relu_test.cpp -Ipl/src -Icommon -o pl/leaky_relu_test` *(fails: hls_stream.h: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_68ab77c43fb4832092c09f53f465bde7