### PR TITLE
Preload biases before input in leaky ReLU test

### DIFF
--- a/pl/src/leaky_relu_test.cpp
+++ b/pl/src/leaky_relu_test.cpp
@@ -1,3 +1,4 @@
+
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include "../../common/data_paths.h"
@@ -21,40 +22,41 @@ int main() {
     hls::stream<axis_t> bias_stream;
     hls::stream<axis_t> out_stream;
 
-    // std::ifstream fin_data(std::string(DATA_DIR) + "/dense_0_output_aie.txt");
     std::ifstream fin_data(std::string(DATA_DIR) + "/" + std::string(EMBED_DENSE1_OUTPUT));
-
     if (!fin_data.is_open()) {
         std::cerr << "ERROR: Cannot open EMBED_DENSE1_OUTPUT" << std::endl;
         return 1;
     }
 
-    // std::ifstream fin_bias(std::string(DATA_DIR) + "/dense_0_bias.txt");
     std::ifstream fin_bias(std::string(DATA_DIR) + "/"  + std::string(EMBED_DENSE1_BIAS));
     if (!fin_bias.is_open()) {
         std::cerr << "ERROR: Cannot open EMBED_DENSE1_BIAS" << std::endl;
         return 1;
     }
 
+    // Preload all bias values before streaming any input data
+    data_t bias_buf[HIDDEN_SIZE];
     for (int i = 0; i < HIDDEN_SIZE; ++i) {
-        data_t val;
-        fin_data >> val;
+        fin_bias >> bias_buf[i];
         axis_t temp;
-        temp.data = val;
+        temp.data = bias_buf[i];
+        temp.keep = -1;
+        temp.last = (i == HIDDEN_SIZE - 1);
+        bias_stream.write(temp);
+    }
+    fin_bias.close();
+
+    // Stream input data after bias preload
+    data_t in_buf[HIDDEN_SIZE];
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
+        fin_data >> in_buf[i];
+        axis_t temp;
+        temp.data = in_buf[i];
         temp.keep = -1;
         temp.last = (i == HIDDEN_SIZE - 1);
         in_stream.write(temp);
-
-        data_t bias_val;
-        fin_bias >> bias_val;
-        axis_t bias_temp;
-        bias_temp.data = bias_val;
-        bias_temp.keep = -1;
-        bias_temp.last = (i == HIDDEN_SIZE - 1);
-        bias_stream.write(bias_temp);
     }
     fin_data.close();
-    fin_bias.close();
 
     leaky_relu_pl(in_stream, bias_stream, out_stream, HIDDEN_SIZE);
 
@@ -64,12 +66,25 @@ int main() {
         return 1;
     }
 
+    bool pass = true;
     for (int i = 0; i < HIDDEN_SIZE; ++i) {
+        data_t expected = in_buf[i] + bias_buf[i];
+        expected = (expected >= 0) ? expected : (expected * LEAKY_SLOPE);
         axis_t temp = out_stream.read();
         fout << temp.data << std::endl;
+        if (temp.data != expected) {
+            std::cerr << "Mismatch at index " << i
+                      << ": expected " << expected
+                      << ", got " << temp.data << std::endl;
+            pass = false;
+        }
     }
     fout.close();
 
-    std::cout << "Testbench completed successfully." << std::endl;
-    return 0;
+    if (pass)
+        std::cout << "Test PASSED - all " << HIDDEN_SIZE << " outputs match." << std::endl;
+    else
+        std::cout << "Test FAILED." << std::endl;
+
+    return pass ? 0 : 1;
 }


### PR DESCRIPTION
## Summary
- Preload all bias values before streaming input data in `leaky_relu_test.cpp`
- Stream data after bias preload and verify outputs against expected leaky ReLU results

## Testing
- `make -C pl sim TARGET=csim KERNELS=leaky_relu` *(fails: `vitis_hls` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab79c625888320819820b154ed577d