### PR TITLE
Add AXI stream switch and dest-based mm2s routing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,9 +29,9 @@ LINK_CFG  := ./common/linker_$(GRAPH).cfg
 DATA_DIR  ?= $(abspath ./data)
 
 ifeq ($(GRAPH),aieml3)
-  HLS_KERNELS := mm2s leaky_relu s2mm
+  HLS_KERNELS := mm2s axis_switch leaky_relu s2mm
 else
-  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm 
+  HLS_KERNELS := mm2s axis_switch leaky_relu leaky_splitter s2mm
 endif
 
 POST_BOOT := post_boot.sh

--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -1,9 +1,9 @@
 [connectivity]
-# Define the number of compute units (CU) for each kernel.
-# This instantiates 6 CUs of mm2s_pl, and 1 for each of the other kernels.
+# Define compute units (CUs) for each kernel. A single mm2s_pl feeds an
+# AXI stream switch which routes data to the appropriate PLIO.
 
-nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,mm2s_bias2
-
+nk=mm2s_pl:1:mm2s_shared
+nk=axis_switch_pl:1:axis_switch
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
 # nk=roll_concat_pl:1:roll_concat  # removed: outputs now routed directly
@@ -12,10 +12,11 @@ nk=s2mm_pl:1:s2mm_out
 # --- Stream Connections ---
 
 # Layer 0: Data and weights streamed from memory into the AIE graph for dense8x128
-stream_connect=mm2s_din.s:ai_engine_0.layer0_in
-stream_connect=mm2s_weights1.s:ai_engine_0.layer0_weights
+stream_connect=mm2s_shared.s:axis_switch.s_in
+stream_connect=axis_switch.out0:ai_engine_0.layer0_in
+stream_connect=axis_switch.out1:ai_engine_0.layer0_weights
 
-stream_connect=mm2s_bias1.s:relu.bias_stream
+stream_connect=axis_switch.out4:relu.bias_stream
 
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
 stream_connect=ai_engine_0.layer0_out:relu.in_stream
@@ -24,10 +25,10 @@ stream_connect=splitter.out_stream_0:ai_engine_0.layer1_in_0
 stream_connect=splitter.out_stream_1:ai_engine_0.layer1_in_1
 
 # Layer 1: Weights streamed from memory into the AIE graph dense128x128
-stream_connect=mm2s_weights2_0.s:ai_engine_0.layer1_weights_0
-stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
+stream_connect=axis_switch.out2:ai_engine_0.layer1_weights_0
+stream_connect=axis_switch.out3:ai_engine_0.layer1_weights_1
 
-stream_connect=mm2s_bias2.s:relu2.bias_stream
+stream_connect=axis_switch.out5:relu2.bias_stream
 
 # Final output from the AIE graph is processed by a second LeakyReLU and
 # written to memory (roll_concat removed)

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -35,7 +35,7 @@ static std::vector<float> read_file_to_vector(const std::string& filename, int s
 struct MM2SInfo {
     std::string file;
     int         size;
-    std::string kernel;
+    int         dest;
     bool        preload;
 };
 
@@ -53,12 +53,12 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
     if (graph == "aieml") {
         GraphConfig cfg;
         cfg.mm2s = {
-            {base_path + "/" + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE, "mm2s_pl:{mm2s_weights1}", true},
-            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, "mm2s_pl:{mm2s_weights2_0}", true},
-            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "1.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, "mm2s_pl:{mm2s_weights2_1}", true},
-            {base_path + "/" + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE, "mm2s_pl:{mm2s_bias1}", true},
-            {base_path + "/" + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE, "mm2s_pl:{mm2s_bias2}", true},
-            {base_path + "/" + EMBED_INPUT_DATA, EMBED_DENSE0_INPUT_SIZE, "mm2s_pl:{mm2s_din}", false},
+            {base_path + "/" + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE, 1, true},
+            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "0.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, 2, true},
+            {base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + "1.txt", EMBED_DENSE1_WEIGHTS_PART_SIZE, 3, true},
+            {base_path + "/" + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE, 4, true},
+            {base_path + "/" + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE, 5, true},
+            {base_path + "/" + EMBED_INPUT_DATA, EMBED_DENSE0_INPUT_SIZE, 0, false},
         };
         cfg.relus = {"leaky_relu_pl:{relu}", "leaky_relu_pl:{relu2}"};
         cfg.splitters = {"leaky_splitter_pl:{splitter}"};
@@ -73,26 +73,26 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
         for (int i = 0; i < SUBSOLVER0_INPUT_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
                                 SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer0_weights_" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 true});
         }
         // Layer 1-3 weights
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
                                 SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer1_weights_" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 true});
         }
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
                                 SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer2_weights_" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 true});
         }
         for (int i = 0; i < SUBSOLVER0_LAYER_WEIGHTS_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX + std::to_string(i) + ".txt",
                                 SUBSOLVER0_LAYER_WEIGHTS_PART_SIZE,
-                                "mm2s_pl:{layer3_weights_" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 true});
         }
         // Biases
@@ -101,14 +101,14 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
         for (int i = 0; i < 4; ++i) {
             cfg.mm2s.push_back({base_path + "/" + bias_files[i],
                                 SUBSOLVER0_LAYER_BIAS_SIZE,
-                                "mm2s_pl:{bias" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 true});
         }
         // Inputs for layer 0
         for (int i = 0; i < SUBSOLVER0_INPUT_PARTS; ++i) {
             cfg.mm2s.push_back({base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX + std::to_string(i) + ".txt",
                                 SUBSOLVER0_INPUT_PART_SIZE,
-                                "mm2s_pl:{layer0_in_" + std::to_string(i) + "}",
+                                (int)cfg.mm2s.size(),
                                 false});
         }
         cfg.relus = {"leaky_relu_pl:{relu0}", "leaky_relu_pl:{relu1}", "leaky_relu_pl:{relu2}", "leaky_relu_pl:{relu3}"};
@@ -121,9 +121,9 @@ static GraphConfig make_config(const std::string& graph, const std::string& base
     } else if (graph == "aieml3") {
         GraphConfig cfg;
         cfg.mm2s = {
-            {base_path + "/" + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE, "mm2s_pl:{mm2s_weights}", true},
-            {base_path + "/" + OUTPUT_DENSE0_BIAS,    OUTPUT_DENSE0_BIAS_SIZE,    "mm2s_pl:{mm2s_bias}",    true},
-            {base_path + "/" + OUTPUT_INPUT_DATA,     OUTPUT_DENSE0_INPUT_SIZE,   "mm2s_pl:{mm2s_din}",     false},
+            {base_path + "/" + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE, 1, true},
+            {base_path + "/" + OUTPUT_DENSE0_BIAS,    OUTPUT_DENSE0_BIAS_SIZE,    2, true},
+            {base_path + "/" + OUTPUT_INPUT_DATA,     OUTPUT_DENSE0_INPUT_SIZE,   0, false},
         };
         cfg.relus = {"leaky_relu_pl:{relu}"};
         cfg.splitters = {};
@@ -167,10 +167,7 @@ int main(int argc, char** argv) {
         xrt::bo output_buf(device, cfg.output_size * sizeof(float), xrt::bo::flags::normal, 0);
 
         // Acquire kernel and graph handles
-        std::vector<xrt::kernel> mm2s_kernels;
-        for (auto& spec : cfg.mm2s) {
-            mm2s_kernels.emplace_back(device, xclbin_uuid, spec.kernel.c_str());
-        }
+        xrt::kernel mm2s_kernel(device, xclbin_uuid, "mm2s_pl:{mm2s_shared}");
         std::vector<xrt::kernel> relu_kernels;
         for (auto& name : cfg.relus) {
             relu_kernels.emplace_back(device, xclbin_uuid, name.c_str());
@@ -203,11 +200,12 @@ int main(int argc, char** argv) {
         }
 
         // Preload weights/biases before starting the AIE graph
-        for (size_t i = 0; i < mm2s_kernels.size(); ++i) {
+        for (size_t i = 0; i < cfg.mm2s.size(); ++i) {
             if (cfg.mm2s[i].preload) {
-                auto run = xrt::run(mm2s_kernels[i]);
+                auto run = xrt::run(mm2s_kernel);
                 run.set_arg(0, mm2s_bos[i]);
                 run.set_arg(2, cfg.mm2s[i].size);
+                run.set_arg(3, cfg.mm2s[i].dest);
                 run.start();
                 run.wait();
             }
@@ -216,19 +214,18 @@ int main(int argc, char** argv) {
         // Run AIE graph
         aie_graph.run(1);
 
-        // Start producers for input data streams
-        std::vector<xrt::run> mm2s_runs;
-        for (size_t i = 0; i < mm2s_kernels.size(); ++i) {
+        // Sequentially send remaining streams after graph start
+        for (size_t i = 0; i < cfg.mm2s.size(); ++i) {
             if (!cfg.mm2s[i].preload) {
-                auto run = xrt::run(mm2s_kernels[i]);
+                auto run = xrt::run(mm2s_kernel);
                 run.set_arg(0, mm2s_bos[i]);
                 run.set_arg(2, cfg.mm2s[i].size);
+                run.set_arg(3, cfg.mm2s[i].dest);
                 run.start();
-                mm2s_runs.push_back(std::move(run));
+                run.wait();
             }
         }
 
-        for (auto& r : mm2s_runs) r.wait();
         aie_graph.wait();
         s2mm_run.wait();
 

--- a/pl/Makefile
+++ b/pl/Makefile
@@ -6,7 +6,7 @@
 VITIS_HLS ?= vitis_hls
 
 # List of kernels (add more as needed)
-KERNELS ?= mm2s leaky_relu leaky_splitter s2mm
+KERNELS ?= mm2s axis_switch leaky_relu leaky_splitter s2mm
 # KERNELS :=
 
 

--- a/pl/axis_switch_project.tcl
+++ b/pl/axis_switch_project.tcl
@@ -1,0 +1,61 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'axis_switch'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "axis_switch"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "${kernel_name}_pl"
+set kernel_file  "src/${kernel_name}_pl.cpp"
+set tb_file      "src/${kernel_name}_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+add_files $kernel_file
+add_files -tb $tb_file
+
+open_solution -flow_target vitis "solution1"
+
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" { csim_design }
+    "csynth" { csynth_design }
+    "cosim" {
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default { puts "ERROR: Unknown command '$command'." }
+}
+
+close_project
+exit

--- a/pl/src/axis_switch_pl.cpp
+++ b/pl/src/axis_switch_pl.cpp
@@ -1,0 +1,39 @@
+#include <ap_int.h>
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+
+typedef float data_t;
+typedef hls::axis<data_t,0,0,4> axis_t;
+
+extern "C" {
+void axis_switch_pl(hls::stream<axis_t>& s_in,
+                    hls::stream<axis_t>& out0,
+                    hls::stream<axis_t>& out1,
+                    hls::stream<axis_t>& out2,
+                    hls::stream<axis_t>& out3,
+                    hls::stream<axis_t>& out4,
+                    hls::stream<axis_t>& out5) {
+#pragma HLS INTERFACE axis port=s_in
+#pragma HLS INTERFACE axis port=out0
+#pragma HLS INTERFACE axis port=out1
+#pragma HLS INTERFACE axis port=out2
+#pragma HLS INTERFACE axis port=out3
+#pragma HLS INTERFACE axis port=out4
+#pragma HLS INTERFACE axis port=out5
+#pragma HLS INTERFACE ap_ctrl_none port=return
+
+    while (true) {
+#pragma HLS PIPELINE II=1
+        axis_t val = s_in.read();
+        switch (val.dest) {
+            case 0: out0.write(val); break;
+            case 1: out1.write(val); break;
+            case 2: out2.write(val); break;
+            case 3: out3.write(val); break;
+            case 4: out4.write(val); break;
+            case 5: out5.write(val); break;
+            default: break;
+        }
+    }
+}
+}

--- a/pl/src/axis_switch_test.cpp
+++ b/pl/src/axis_switch_test.cpp
@@ -1,0 +1,35 @@
+#include <iostream>
+#include <hls_stream.h>
+#include <ap_axi_sdata.h>
+
+typedef float data_t;
+typedef hls::axis<data_t,0,0,4> axis_t;
+
+extern "C" void axis_switch_pl(hls::stream<axis_t>& s_in,
+                                hls::stream<axis_t>& out0,
+                                hls::stream<axis_t>& out1,
+                                hls::stream<axis_t>& out2,
+                                hls::stream<axis_t>& out3,
+                                hls::stream<axis_t>& out4,
+                                hls::stream<axis_t>& out5);
+
+int main() {
+    hls::stream<axis_t> in;
+    hls::stream<axis_t> out0, out1, out2, out3, out4, out5;
+    for(int i=0;i<6;++i){
+        axis_t val; val.data=i; val.dest=i;
+        in.write(val);
+    }
+    axis_switch_pl(in,out0,out1,out2,out3,out4,out5);
+    bool pass=true;
+    hls::stream<axis_t>* outs[6]={&out0,&out1,&out2,&out3,&out4,&out5};
+    for(int i=0;i<6;++i){
+        if(outs[i]->empty()){std::cerr<<"Output "<<i<<" empty\n"; pass=false; continue;}
+        axis_t val=outs[i]->read();
+        if(val.data!=i){std::cerr<<"Mismatch at output "<<i<<"\n"; pass=false;}
+        if(!outs[i]->empty()){std::cerr<<"Extra data at output "<<i<<"\n"; pass=false;}
+    }
+    if(pass) std::cout<<"Test PASSED"<<std::endl;
+    else std::cout<<"Test FAILED"<<std::endl;
+    return pass?0:1;
+}

--- a/pl/src/mm2s_pl.cpp
+++ b/pl/src/mm2s_pl.cpp
@@ -3,11 +3,11 @@
 #include <ap_axi_sdata.h>
 
 typedef float data_t;
-typedef hls::axis<data_t, 0, 0, 0> axis_t;
+typedef hls::axis<data_t, 0, 0, 4> axis_t;
 
 extern "C" {
     // Move data from memory to an AXI stream
-    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int size) {
+    void mm2s_pl(float* mem, hls::stream<axis_t>& s, int size, int dest) {
         #pragma HLS INTERFACE m_axi port=mem offset=slave bundle=gmem depth=4096
         #ifndef __SYNTHESIS__
             #pragma HLS INTERFACE axis port=s depth=4096
@@ -16,11 +16,13 @@ extern "C" {
         #endif
         #pragma HLS INTERFACE s_axilite port=mem bundle=control
         #pragma HLS INTERFACE s_axilite port=size bundle=control
+        #pragma HLS INTERFACE s_axilite port=dest bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 
         for (int i = 0; i < size; ++i) {
             #pragma HLS PIPELINE II=1
             axis_t val; val.data = mem[i];
+            val.dest = dest;
             s.write(val);
         }
     }

--- a/pl/src/mm2s_test.cpp
+++ b/pl/src/mm2s_test.cpp
@@ -6,9 +6,9 @@
 #include <fstream>
 
 typedef float data_t;
-typedef hls::axis<data_t, 0, 0, 0> axis_t;
+typedef hls::axis<data_t, 0, 0, 4> axis_t;
 
-extern "C" void mm2s_pl(float* mem, hls::stream<axis_t>& s, int size);
+extern "C" void mm2s_pl(float* mem, hls::stream<axis_t>& s, int size, int dest);
 
 constexpr int SIZE = 8;
 
@@ -27,7 +27,7 @@ int main() {
     }
 
     hls::stream<axis_t> s_out;
-    mm2s_pl(mem, s_out, SIZE);
+    mm2s_pl(mem, s_out, SIZE, 0);
 
     bool pass = true;
     for (int i = 0; i < SIZE; ++i) {


### PR DESCRIPTION
## Summary
- Add free-running AXI stream switch kernel to distribute mm2s output among PLIOs
- Extend mm2s kernel with TDEST field and host-controlled destination argument
- Rework host application and connectivity to run a single mm2s instance sequentially through the switch

## Testing
- `DATA_DIR=../data make -C pl sim TARGET=csim KERNELS="mm2s axis_switch"` *(fails: vitis_hls: not found)*
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a03df0883208183cdc7f63a6aeb