### PR TITLE
Add dynamic VEK280 environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This project demonstrates a custom low-latency neural network pipeline implemented on the AMD Versal™ VEK280 platform using the AI Engine-ML (AIE-ML) and Vitis tools. The core model consists of two dense layers with leaky ReLU activations after each layer, targeting power-efficient acceleration of small MLP inference tasks. It supports runtime configurability of dimensions and data types (`int8`, `int16`, `float16`, `float32`), with automated test data generation and full simulation support.
 
+> **Note**: source `set_envs.sh` first.
 The design partitions work across three components of the Versal architecture:
 
 - **AI Engine‑ML graphs** – execute dense layers. The project now contains three


### PR DESCRIPTION
## Summary
- add script that validates Vitis 2024.2 and auto-selects VEK280 base platform
- document sourcing the environment script before builds

## Testing
- `bash -n set_envs.sh`
- `source set_envs.sh` then `echo $PLATFORM`
- `shellcheck set_envs.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac655fb79483209de807f7390c0453