### PR TITLE
Export packet ID headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ source set_envs.sh
    ```bash
    make -C aieml graph
    ```
+   The build also exports packet-switch packet IDs to `export/generated/packet_ids.h`
+   for inclusion by the PL and other components.
 3. **Kernel build (PL)**
    ```bash
    make -C pl kernels

--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -86,8 +86,16 @@ $(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 		exit 1; \
 	fi
 	@set -o pipefail; \
-	$(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
-	@echo "COMPLETE: AIE graph compiled."
+        $(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
+        @echo "COMPLETE: AIE graph compiled."
+	@hdr_file=`find $(WORK_DIR) -name packet_ids.h | head -n 1`; \
+	if [ -n "$$hdr_file" ]; then \
+	mkdir -p ../export/generated; \
+	cp $$hdr_file ../export/generated/packet_ids.h; \
+	echo "EXPORTED: packet IDs header to ../export/generated/packet_ids.h"; \
+	else \
+	echo "WARNING: packet_ids.h not found under $(WORK_DIR)"; \
+	fi
 
 # --- Simulation ---
 sim: graph

--- a/export/generated/packet_ids.h
+++ b/export/generated/packet_ids.h
@@ -1,0 +1,4 @@
+#pragma once
+// Generated packet ID definitions.
+// This file is auto-generated during AIE compilation.
+// Do not edit manually.


### PR DESCRIPTION
## Summary
- Copy AI Engine generated packet ID header into a stable export path for downstream builds
- Document location of exported packet IDs in the workflow
- Add placeholder packet_ids.h exported header

## Testing
- `make -C aieml graph` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68ac6a3257b483208e22cc261072ea39