### PR TITLE
Link aieml graph with packet-mover kernels

### DIFF
--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -1,38 +1,9 @@
 [connectivity]
-# Define compute units (CUs) for each kernel. A single mm2s_pl feeds an
-# AXI stream switch which routes data to the appropriate PLIO.
+nk=mm2s_pkt_weights:1:mm2s_pkt_weights
+nk=mm2s_pkt_data:1:mm2s_pkt_data
+nk=s2mm_pkt_sink:1:s2mm_pkt_sink
 
-nk=mm2s_pl:1:mm2s_shared
-nk=axis_switch_pl:1:axis_switch
-nk=leaky_relu_pl:2:relu,relu2
-nk=leaky_splitter_pl:1:splitter
-# nk=roll_concat_pl:1:roll_concat  # removed: outputs now routed directly
-nk=s2mm_pl:1:s2mm_out
-
-# --- Stream Connections ---
-
-# Layer 0: Data and weights streamed from memory into the AIE graph for dense8x128
-stream_connect=mm2s_shared.s:axis_switch.s_in
-stream_connect=axis_switch.out0:ai_engine_0.layer0_in
-stream_connect=axis_switch.out1:ai_engine_0.layer0_weights
-
-stream_connect=axis_switch.out4:relu.bias_stream
-
-# Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
-stream_connect=ai_engine_0.layer0_out:relu.in_stream
-stream_connect=relu.out_stream:splitter.in_stream
-stream_connect=splitter.out_stream_0:ai_engine_0.layer1_in_0
-stream_connect=splitter.out_stream_1:ai_engine_0.layer1_in_1
-
-# Layer 1: Weights streamed from memory into the AIE graph dense128x128
-stream_connect=axis_switch.out2:ai_engine_0.layer1_weights_0
-stream_connect=axis_switch.out3:ai_engine_0.layer1_weights_1
-
-stream_connect=axis_switch.out5:relu2.bias_stream
-
-# Final output from the AIE graph is processed by a second LeakyReLU and
-# written to memory (roll_concat removed)
-stream_connect=ai_engine_0.layer1_out:relu2.in_stream
-stream_connect=relu2.out_stream:s2mm_out.s
-
+stream_connect=mm2s_pkt_weights.s:ai_engine_0.in_weights
+stream_connect=mm2s_pkt_data.s:ai_engine_0.in_data
+stream_connect=ai_engine_0.out_merged:s2mm_pkt_sink.s
 

--- a/system_project.yaml
+++ b/system_project.yaml
@@ -15,15 +15,15 @@ components:
 
   - name: aie_graph
     type: aie
-    path: aie
+    path: aieml
 
   - name: pl_kernels
     type: kernel
-    path: pl/build_hw_emu
+    path: pl
     kernels:
-      - mm2s_8_128.xo
-      - s2mm_16_128.xo
-      - s2mm_32_128.xo
+      - mm2s_pkt_weights.xo
+      - mm2s_pkt_data.xo
+      - s2mm_pkt_sink.xo
 
   - name: hw_link_output
     type: xsa


### PR DESCRIPTION
## Summary
- Link packetized PL kernels to the aieml graph
- Drive link with prebuilt packet kernels and AIE library
- Simplify system project to include packet kernel objects

## Testing
- `make package TARGET=hw_emu GRAPH=aieml` *(fails: no rule to make target `Work/libadf.a`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6b9778288320907d30779dfd40d6