### PR TITLE
feat(host): drive packetized data flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ source set_envs.sh
    make package
    ```
 
+6. **Run the host application**
+   Pass the generated `xclbin` to the host executable (path will vary with build target, e.g. hardware emulation shown below):
+   ```bash
+   ./host/system_host system_project/_x.hw_emu/system.xclbin
+   ```
+
 ---
 
 ## 🧪 Generate Dummy Test Data & Weights


### PR DESCRIPTION
## Summary
- Stream weights and activations using mm2s_pkt kernels and stop the aieml graph after packets are sent
- Demultiplex s2mm output packets by destination ID for order-agnostic collection
- Document packetized host app flow and quick run instructions

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6df9b8408320b0a9465aabbde160