### PR TITLE
Add switch_mm2s HLS project script

### DIFF
--- a/pl/switch_mm2s_project.tcl
+++ b/pl/switch_mm2s_project.tcl
@@ -1,0 +1,77 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'switch_mm2s'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "switch_mm2s"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "weights_mm2s"  ;# or "switch_mm2s_pl" if function renamed
+set kernel_file  "src/switch_mm2s_pl.cpp"
+set tb_file      "src/switch_mm2s_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+# Add your project's specific source files from src/
+add_files $kernel_file
+add_files -tb $tb_file
+add_files -tb ../data/leakyrelu_output_ref.txt
+
+# Use the -flow_target vitis flag for correct XO generation
+open_solution -flow_target vitis "solution1"
+
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" {
+        puts "### Running C Simulation... ###"
+        csim_design
+    }
+    "csynth" {
+        puts "### Running C Synthesis... ###"
+        csynth_design
+    }
+    "cosim" {
+        puts "### Running Synthesis and Co-simulation... ###"
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        puts "### Running Synthesis and Exporting IP... ###"
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        puts "### Running Synthesis and Exporting XO... ###"
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        puts "### Running Synthesis... ###"
+        csynth_design
+        puts "### Exporting XO and IP Catalog... ###"
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default {
+        puts "ERROR: Unknown command '$command'."
+    }
+}
+
+close_project
+exit


### PR DESCRIPTION
## Summary
- add Vitis HLS TCL project for switch_mm2s kernel

## Testing
- `tclsh pl/switch_mm2s_project.tcl csim` *(fails: invalid command name "open_project" – Vitis HLS not installed)*
- `make -C pl kernels` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9117d6688320aae6985d06e25464