### PR TITLE
Add testbench and build script for demux_8 PL kernel

### DIFF
--- a/pl/demux_8_project.tcl
+++ b/pl/demux_8_project.tcl
@@ -1,0 +1,74 @@
+# ===================================================================
+# Vitis HLS Project TCL Script for 'demux_8'
+# ===================================================================
+
+# --- Step 1: User Configuration ---
+set kernel_name "demux_8"
+set part_name   "xcve2802-vsvh1760-2MP-e-S"
+
+# --- Step 2: Automatic Naming ---
+set project_name "${kernel_name}_hls"
+set top_function "weights_demux_8"
+set kernel_file  "src/demux_8_pl.cpp"
+set tb_file      "src/demux_8_test.cpp"
+
+# --- Step 3: Command Handling ---
+if {$argc > 0} {
+    set command [lindex $argv 0]
+} else {
+    puts "ERROR: Please provide a command."
+    puts "Usage: vitis_hls -f project.tcl <command>"
+    exit 1
+}
+
+# --- Step 4: Project and Solution Setup ---
+open_project $project_name
+set_top $top_function
+
+add_files $kernel_file
+add_files -tb $tb_file
+
+open_solution -flow_target vitis "solution1"
+
+set_part ${part_name}
+create_clock -period 3.33 -name default
+
+# --- Step 5: Execute Command ---
+switch $command {
+    "csim" {
+        puts "### Running C Simulation... ###"
+        csim_design
+    }
+    "csynth" {
+        puts "### Running C Synthesis... ###"
+        csynth_design
+    }
+    "cosim" {
+        puts "### Running Synthesis and Co-simulation... ###"
+        csynth_design
+        cosim_design -rtl verilog -trace_level all
+    }
+    "export_ip" {
+        puts "### Running Synthesis and Exporting IP... ###"
+        csynth_design
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    "export_xo" {
+        puts "### Running Synthesis and Exporting XO... ###"
+        csynth_design
+        export_design -format xo -output ./ip/${project_name}.xo
+    }
+    "kernels" {
+        puts "### Running Synthesis... ###"
+        csynth_design
+        puts "### Exporting XO and IP Catalog... ###"
+        export_design -format xo -output ./ip/${project_name}.xo
+        export_design -format ip_catalog -output ./ip/${project_name}_ip
+    }
+    default {
+        puts "ERROR: Unknown command '$command'."
+    }
+}
+
+close_project
+exit

--- a/pl/src/demux_8_test.cpp
+++ b/pl/src/demux_8_test.cpp
@@ -1,0 +1,92 @@
+#include <ap_axi_sdata.h>
+#include <ap_int.h>
+#include <cassert>
+#include <hls_stream.h>
+#include <iostream>
+
+// axis_t definition matches demux_8_pl.cpp
+typedef ap_axiu<32, 1, 1, 8> axis_t; // data,user,id,dest
+
+extern "C" void
+weights_demux_8(hls::stream<axis_t> &in, hls::stream<axis_t> &out0,
+                hls::stream<axis_t> &out1, hls::stream<axis_t> &out2,
+                hls::stream<axis_t> &out3, hls::stream<axis_t> &out4,
+                hls::stream<axis_t> &out5, hls::stream<axis_t> &out6,
+                hls::stream<axis_t> &out7);
+
+int main() {
+  hls::stream<axis_t> in;
+  hls::stream<axis_t> out0, out1, out2, out3, out4, out5, out6, out7;
+
+  const int packet_len = 3;
+
+  // First packet routed to output 3
+  for (int i = 0; i < packet_len; ++i) {
+    axis_t t;
+    t.data = 0x10 + i;
+    t.keep = -1;
+    t.last = (i == packet_len - 1);
+    t.dest = 3;
+    t.id = 0;
+    t.user = 0;
+    in.write(t);
+  }
+
+  // Second packet routed to output 7
+  for (int i = 0; i < packet_len; ++i) {
+    axis_t t;
+    t.data = 0x20 + i;
+    t.keep = -1;
+    t.last = (i == packet_len - 1);
+    t.dest = 7;
+    t.id = 0;
+    t.user = 0;
+    in.write(t);
+  }
+
+  weights_demux_8(in, out0, out1, out2, out3, out4, out5, out6, out7);
+
+  bool pass = true;
+
+  // Check output 3
+  for (int i = 0; i < packet_len; ++i) {
+    assert(!out3.empty());
+    axis_t v = out3.read();
+    bool last = (i == packet_len - 1);
+    if (v.data != (ap_uint<32>)(0x10 + i) || v.last != last)
+      pass = false;
+    assert(v.dest == 0);
+  }
+  if (!out3.empty())
+    pass = false;
+
+  // Check output 7
+  for (int i = 0; i < packet_len; ++i) {
+    assert(!out7.empty());
+    axis_t v = out7.read();
+    bool last = (i == packet_len - 1);
+    if (v.data != (ap_uint<32>)(0x20 + i) || v.last != last)
+      pass = false;
+    assert(v.dest == 0);
+  }
+  if (!out7.empty())
+    pass = false;
+
+  // Other outputs should be empty
+  hls::stream<axis_t> *outs[8] = {&out0, &out1, &out2, &out3,
+                                  &out4, &out5, &out6, &out7};
+  for (int i = 0; i < 8; ++i) {
+    if (i == 3 || i == 7)
+      continue;
+    if (!outs[i]->empty())
+      pass = false;
+  }
+
+  if (pass) {
+    std::cout << "Test PASSED" << std::endl;
+    return 0;
+  } else {
+    std::cout << "Test FAILED" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add Vitis HLS project Tcl for demux_8 kernel
- create simple C++ testbench exercising routing to outputs 3 and 7

## Testing
- `g++ -std=c++17 pl/src/demux_8_test.cpp pl/src/demux_8_pl.cpp -Ipl/src -Icommon -o /tmp/demux_test` *(fails: ap_axi_sdata.h: No such file or directory)*
- `timeout 10s vitis_hls -f pl/demux_8_project.tcl csim` *(fails: vitis_hls: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac92a4f9a48320bfa41f7c06535e1e