### PR TITLE
Add simulation guard and finite-beat testbench for demux

### DIFF
--- a/pl/src/demux_8_test.cpp
+++ b/pl/src/demux_8_test.cpp
@@ -16,30 +16,25 @@ extern "C" void demux_8(hls::stream<axis_t> &in, hls::stream<axis_t> &out0,
 int main() {
   hls::stream<axis_t> in;
   hls::stream<axis_t> out0, out1, out2, out3, out4, out5, out6, out7;
-
   const int packet_len = 3;
+  const int NUM_BEATS = packet_len * 2;
 
-  // First packet routed to output 3
-  for (int i = 0; i < packet_len; ++i) {
+  // Preload input stream with NUM_BEATS beats
+  for (int i = 0; i < NUM_BEATS; ++i) {
     axis_t t;
-    t.data = 0x10 + i;
     t.keep = -1;
-    t.last = (i == packet_len - 1);
-    t.dest = 3;
-    t.id = 0;
+    t.id   = 0;
     t.user = 0;
-    in.write(t);
-  }
-
-  // Second packet routed to output 7
-  for (int i = 0; i < packet_len; ++i) {
-    axis_t t;
-    t.data = 0x20 + i;
-    t.keep = -1;
-    t.last = (i == packet_len - 1);
-    t.dest = 7;
-    t.id = 0;
-    t.user = 0;
+    if (i < packet_len) {
+      t.data = 0x10 + i;
+      t.dest = 3;
+      t.last = (i == packet_len - 1);
+    } else {
+      int j = i - packet_len;
+      t.data = 0x20 + j;
+      t.dest = 7;
+      t.last = (i == NUM_BEATS - 1);
+    }
     in.write(t);
   }
 


### PR DESCRIPTION
## Summary
- Add simulation-only loop with NUM_BEATS and return in `demux_8_pl.cpp`, keeping original infinite loop for synthesis
- Introduce NUM_BEATS constant in the testbench and preload input stream accordingly before running `demux_8`

## Testing
- `g++ -std=c++11 pl/src/demux_8_pl.cpp pl/src/demux_8_test.cpp -o /tmp/demux_8_test` *(fails: ap_int.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9b8850748320be10526d9c1a7d82