### PR TITLE
Implement switch-based mm2s with demux routing and packetized host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,10 @@ DATA_DIR  ?= $(abspath ./data)
 
 ifeq ($(GRAPH),aieml3)
   HLS_KERNELS := mm2s leaky_relu s2mm
+else ifeq ($(GRAPH),aieml)
+  HLS_KERNELS := switch_mm2s demux_8 leaky_relu leaky_splitter s2mm
 else
-  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm 
+  HLS_KERNELS := mm2s leaky_relu leaky_splitter s2mm
 endif
 
 POST_BOOT := post_boot.sh

--- a/common/linker_aieml.cfg
+++ b/common/linker_aieml.cfg
@@ -1,9 +1,8 @@
 [connectivity]
 # Define the number of compute units (CU) for each kernel.
-# This instantiates 6 CUs of mm2s_pl, and 1 for each of the other kernels.
 
-nk=mm2s_pl:6:mm2s_din,mm2s_weights1,mm2s_weights2_0,mm2s_weights2_1,mm2s_bias1,mm2s_bias2
-
+nk=switch_mm2s_pl:1:mm2s_switch
+nk=demux_8_pl:1:demux
 nk=leaky_relu_pl:2:relu,relu2
 nk=leaky_splitter_pl:1:splitter
 # nk=roll_concat_pl:1:roll_concat  # removed: outputs now routed directly
@@ -12,10 +11,11 @@ nk=s2mm_pl:1:s2mm_out
 # --- Stream Connections ---
 
 # Layer 0: Data and weights streamed from memory into the AIE graph for dense8x128
-stream_connect=mm2s_din.s:ai_engine_0.layer0_in
-stream_connect=mm2s_weights1.s:ai_engine_0.layer0_weights
+stream_connect=mm2s_switch.out:demux.in
+stream_connect=demux.out0:ai_engine_0.layer0_in
+stream_connect=demux.out1:ai_engine_0.layer0_weights
 
-stream_connect=mm2s_bias1.s:relu.bias_stream
+stream_connect=demux.out4:relu.bias_stream
 
 # Feedback loop: AIE output -> leaky_relu -> splitter -> AIE input for the next layer
 stream_connect=ai_engine_0.layer0_out:relu.in_stream
@@ -24,10 +24,10 @@ stream_connect=splitter.out_stream_0:ai_engine_0.layer1_in_0
 stream_connect=splitter.out_stream_1:ai_engine_0.layer1_in_1
 
 # Layer 1: Weights streamed from memory into the AIE graph dense128x128
-stream_connect=mm2s_weights2_0.s:ai_engine_0.layer1_weights_0
-stream_connect=mm2s_weights2_1.s:ai_engine_0.layer1_weights_1
+stream_connect=demux.out2:ai_engine_0.layer1_weights_0
+stream_connect=demux.out3:ai_engine_0.layer1_weights_1
 
-stream_connect=mm2s_bias2.s:relu2.bias_stream
+stream_connect=demux.out5:relu2.bias_stream
 
 # Final output from the AIE graph is processed by a second LeakyReLU and
 # written to memory (roll_concat removed)

--- a/pl/bus_ids.hpp
+++ b/pl/bus_ids.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+// Logical stream IDs used by the switch_mm2s and demux kernels.
+// These values are placed in the packet header and map directly to the
+// TDEST field consumed by the demux_8_pl kernel.
+
+namespace bus {
+
+// Input feature stream for layer 0.
+constexpr std::uint8_t DIN         = 0;
+
+// Layer 0 weight stream.
+constexpr std::uint8_t WEIGHTS0    = 1;
+
+// Layer 1 weight streams (split in two parts).
+constexpr std::uint8_t WEIGHTS1_A  = 2;
+constexpr std::uint8_t WEIGHTS1_B  = 3;
+
+// Bias streams for layers 0 and 1.
+constexpr std::uint8_t BIAS0       = 4;
+constexpr std::uint8_t BIAS1       = 5;
+
+} // namespace bus
+

--- a/pl/src/switch_mm2s_pl.cpp
+++ b/pl/src/switch_mm2s_pl.cpp
@@ -2,6 +2,7 @@
 #include <hls_stream.h>
 #include <stdint.h>
 #include <ap_axi_sdata.h> // ap_axiu
+#include "../bus_ids.hpp"
 
 // 32-bit data, 1-bit user, 1-bit id, 8-bit dest
 typedef ap_axiu<32,1,1,8> axis_t;
@@ -31,9 +32,9 @@ void switch_mm2s_pl(const ap_uint<32>* in,      // AXI4-MM (DDR)
     ap_uint<32> w1 = in[idx + 1];
     idx += WORDS_PER_HDR;
 
-    ap_uint<8>  part     = w0.range(31,24);
-    ap_uint<8>  kind     = w0.range(23,16);
-    ap_uint<8>  layer_id = w0.range(7,0);
+    ap_uint<8>  part    = w0.range(31,24);
+    ap_uint<8>  kind    = w0.range(23,16);
+    ap_uint<8>  bus_id  = w0.range(7,0);
     uint32_t    len_words= (uint32_t)w1;
 
     if (idx + len_words > total_words) break; // guard
@@ -47,7 +48,7 @@ void switch_mm2s_pl(const ap_uint<32>* in,      // AXI4-MM (DDR)
       t.strb = -1;
       t.user = 0;
       t.id   = 0;
-      t.dest = layer_id;
+      t.dest = bus_id;
       t.last = (i == len_words - 1);
       out.write(t);
     }

--- a/pl/src/switch_mm2s_test.cpp
+++ b/pl/src/switch_mm2s_test.cpp
@@ -3,6 +3,7 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include <cassert>
+#include "../bus_ids.hpp"
 
 // axis_t definition matches switch_mm2s_pl.cpp
 typedef ap_axiu<32,1,1,8> axis_t; // data,user,id,dest
@@ -18,7 +19,7 @@ extern "C" void switch_mm2s_pl(const ap_uint<32>* in,
 int main() {
     const ap_uint<8> part = 1;
     const ap_uint<8> kind = 2;
-    const ap_uint<8> layer_id = 3;
+    const ap_uint<8> bus_id = bus::DIN;
     const int payload_len = 3;
 
     ap_uint<32> payload[payload_len] = {0xdeadbeef, 0xcafebabe, 0x12345678};
@@ -27,7 +28,7 @@ int main() {
     // ap_uint<32> mem[total_words];
     static ap_uint<32> mem[MEM_DEPTH] = {0};  // must be >= pragma depth
 
-    mem[0] = (part << 24) | (kind << 16) | (layer_id);
+    mem[0] = (part << 24) | (kind << 16) | (bus_id);
     mem[1] = payload_len;
     mem[2] = 0;
     mem[3] = 0;
@@ -43,11 +44,11 @@ int main() {
         assert(!out.empty());
         axis_t val = out.read();
         bool last = (i == payload_len - 1);
-        if (val.data != payload[i] || val.dest != layer_id || val.last != last) {
+        if (val.data != payload[i] || val.dest != bus_id || val.last != last) {
             pass = false;
         }
         assert(val.data == payload[i]);
-        assert(val.dest == layer_id);
+        assert(val.dest == bus_id);
         assert(val.last == last);
     }
     if (!out.empty()) {


### PR DESCRIPTION
## Summary
- Replace six mm2s kernels with single switch_mm2s_pl and demux_8_pl in linker
- Introduce shared bus ID definitions and packet-based host streaming
- Update switch kernel and tests to route by bus ID

## Testing
- `make aie TARGET=sw_emu EMU_PS=x86sim GRAPH=aieml` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*
- `make host TARGET=sw_emu` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make link TARGET=sw_emu EMU_PS=x86sim GRAPH=aieml` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68acf70c76b883208286ab211536cbc4