### PR TITLE
Add runtime word count to demux kernel

### DIFF
--- a/pl/src/demux_8_test.cpp
+++ b/pl/src/demux_8_test.cpp
@@ -11,7 +11,7 @@ extern "C" void demux_8_pl(hls::stream<axis_t> &in, hls::stream<axis_t> &out0,
                          hls::stream<axis_t> &out1, hls::stream<axis_t> &out2,
                          hls::stream<axis_t> &out3, hls::stream<axis_t> &out4,
                          hls::stream<axis_t> &out5, hls::stream<axis_t> &out6,
-                         hls::stream<axis_t> &out7);
+                         hls::stream<axis_t> &out7, unsigned int word_count);
 
 int main() {
   hls::stream<axis_t> in;
@@ -38,7 +38,7 @@ int main() {
     in.write(t);
   }
 
-  demux_8_pl(in, out0, out1, out2, out3, out4, out5, out6, out7);
+  demux_8_pl(in, out0, out1, out2, out3, out4, out5, out6, out7, NUM_BEATS);
 
   bool pass = true;
 


### PR DESCRIPTION
## Summary
- Add `word_count` AXI-Lite argument to `demux_8_pl` and process a finite number of beats
- Update host to compute total word count, set argument, and wait/stop the demux run
- Adjust demux test for new kernel signature

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make -C pl KERNELS=demux_8` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad19c4e5248320adc2250629b1ae10