### PR TITLE
Wait for all kernels to complete before program exit

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -151,6 +151,9 @@ int main(int argc, char** argv) {
     input_run.wait();
     aie_graph.wait();
     s2mm_run.wait();
+    relu_run.wait();
+    relu2_run.wait();
+    split_run.wait();
     demux_run.wait();
     demux_run.stop();
 


### PR DESCRIPTION
## Summary
- Ensure host waits for relu, relu2, and splitter kernels after s2mm completion
- Confirm PL kernels use `ap_ctrl_hs` via `s_axilite port=return`

## Testing
- `g++ pl/src/leaky_relu_test.cpp -o /tmp/leaky_relu_test` *(fails: hls_stream.h: No such file or directory)*
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad21ffb4c48320a46ea140f89b64cb