### PR TITLE
Ensure AIE graph termination before kernel shutdown

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -150,6 +150,7 @@ int main(int argc, char** argv) {
 
     input_run.wait();
     aie_graph.wait();
+    aie_graph.end();
     s2mm_run.wait();
     demux_run.wait();
     demux_run.stop();


### PR DESCRIPTION
## Summary
- Call `aie_graph.end()` after waiting for graph completion to signal termination

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2249d1888320832ee048ce60f09a