### PR TITLE
Fix demux argument index

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv) {
     unsigned int demux_words = weight_words.size() + input_words.size();
     // Start demux first, then other consumer kernels
     auto demux_run = xrt::run(demux_kernel);
-    demux_run.set_arg(0, demux_words);
+    demux_run.set_arg(9, demux_words);
     demux_run.start();
 
     auto s2mm_run = xrt::run(s2mm_kernel);


### PR DESCRIPTION
## Summary
- Set demux kernel argument index to 9 to accommodate 1 input plus 8 outputs

## Testing
- `make run TARGET=hw_emu` *(fails: Directory not found '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*


------
https://chatgpt.com/codex/tasks/task_e_68adc30e4eb48320a6f70e5d6dc4b2b3