### PR TITLE
Remove redundant demux stop call

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -156,7 +156,6 @@ int main(int argc, char** argv) {
     relu2_run.wait();
     split_run.wait();
     demux_run.wait();
-    demux_run.stop();
 
     // Retrieve results
     std::vector<float> host_output_data(EMBED_FINAL_OUTPUT_SIZE);


### PR DESCRIPTION
## Summary
- avoid calling `stop()` after `demux_run.wait()` in host flow

## Testing
- `make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adc3b3fb408320abf42dfd75955e4d