### PR TITLE
Adjust AXI stream interfaces for leaky ReLU kernel

### DIFF
--- a/pl/src/leaky_relu_pl.cpp
+++ b/pl/src/leaky_relu_pl.cpp
@@ -12,9 +12,9 @@ extern "C" {
                        hls::stream<axis_t>& bias_stream,
                        hls::stream<axis_t>& out_stream,
                        int size) {
-        #pragma HLS interface axis port=in_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
-        #pragma HLS interface axis port=bias_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
-        #pragma HLS interface axis port=out_stream bundle=gmem depth=OUTPUT_DENSE0_OUT_PAD
+        #pragma HLS interface axis port=in_stream depth=HIDDEN_SIZE
+        #pragma HLS interface axis port=bias_stream depth=HIDDEN_SIZE
+        #pragma HLS interface axis port=out_stream depth=HIDDEN_SIZE
         #pragma HLS INTERFACE s_axilite port=size bundle=control
         #pragma HLS INTERFACE s_axilite port=return bundle=control
 


### PR DESCRIPTION
## Summary
- remove gmem bundles from leaky_relu AXI stream ports
- set stream depths to HIDDEN_SIZE for all ports

## Testing
- `make -C pl kernels` *(fails: `vitis_hls: not found`)*
- `make package` *(fails: `Work/libadf.a` error)*

------
https://chatgpt.com/codex/tasks/task_e_68adc4454dcc8320a838604581a62753