### PR TITLE
Initialize AI Engine graph before preloading weights

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -114,6 +114,9 @@ int main(int argc, char** argv) {
     xrt::kernel s2mm_kernel(device, uuid, "s2mm_pl:{s2mm_out}");
     xrt::graph  aie_graph(device, uuid, "g");
 
+    // Initialize AI Engine graph before any data movement
+    aie_graph.init();
+
     unsigned int demux_words = weight_words.size() + input_words.size();
     // Start demux first, then other consumer kernels
     auto demux_run = xrt::run(demux_kernel);


### PR DESCRIPTION
## Summary
- Initialize the AI Engine graph once kernels are created so weights can be preloaded safely.
- Run the AI Engine graph only after weights and biases have been streamed in.

## Testing
- `make host TARGET=hw_emu` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make run TARGET=hw_emu` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68adcb78d15c8320b5945592baf7bb3f