### PR TITLE
Set AXIS last flag in leaky splitter kernel

### DIFF
--- a/pl/src/leaky_splitter_pl.cpp
+++ b/pl/src/leaky_splitter_pl.cpp
@@ -20,6 +20,7 @@ extern "C" {
             #pragma HLS pipeline II=1
             axis_t val = in_stream.read();
             int out_idx = i / SPLIT_SIZE;
+            val.last = ((i % SPLIT_SIZE) == SPLIT_SIZE - 1);
             out_stream[out_idx].write(val);
         }
     }


### PR DESCRIPTION
## Summary
- ensure leaky splitter sets AXI `last` flag on final element of each split

## Testing
- `make -C pl KERNELS=leaky_splitter` *(fails: vitis_hls: not found)*
- `make link` *(fails: Directory not found: '/home/synthara/VersalPrjs/Vitis_Libraries/dsp')*

------
https://chatgpt.com/codex/tasks/task_e_68adce2f3fcc8320b0e31c155d78af7d