### PR TITLE
Simplify host to sequential packet streaming

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -1,4 +1,4 @@
-# Makefile to compile host.cpp for PetaLinux sysroot using aarch64-linux-gnu-g++
+# Simple Makefile to build host.cpp
 
 # Toolchain and paths
 SYSROOT ?= /opt/petalinux/2024.2/sysroots/cortexa72-cortexa53-xilinx-linux
@@ -9,33 +9,28 @@ export DATA_DIR
 
 # Sources and targets
 SRC := host.cpp
-OBJ := $(SRC:.cpp=.o)
 OUT ?= system_host
 
 # Compiler and linker flags
-CXXFLAGS ?= -Wall -c -std=c++17 -Wno-int-to-pointer-cast \
+CXXFLAGS ?= -Wall -std=c++17 -Wno-int-to-pointer-cast \
         --sysroot=$(SYSROOT) \
         -I$(SYSROOT)/usr/include/xrt \
         -I$(SYSROOT)/usr/include \
-        -I./ -I./src/ -I../common -I/aietools/include -I/include \
+        -I./ -I../common -I/aietools/include -I/include \
         -DDATA_DIR='"$(DATA_DIR)"'
 
 LDFLAGS ?= --sysroot=$(SYSROOT) \
-	-L$(SYSROOT)/usr/lib \
-	-lstdc++ -lxrt_coreutil -lxrt_core -lpthread
+        -L$(SYSROOT)/usr/lib \
+        -lstdc++ -lxrt_coreutil -lxrt_core -lpthread
 
 .PHONY: all clean
 
 all: $(OUT)
 
-$(OBJ): $(SRC)
-	$(CXX) $(CXXFLAGS) -o $@ $<
-
-$(OUT): $(OBJ)
-	$(CXX) $^ $(LDFLAGS) -o $@
+$(OUT): $(SRC)
+	$(CXX) $(CXXFLAGS) $< $(LDFLAGS) -o $@
 	@echo "✅ Built host executable: $(OUT)"
 
 clean:
-	rm -f $(OBJ) $(OUT) *.log
+	rm -f $(OUT) *.log
 	@echo "🧹 Cleaned up build artifacts"
-

--- a/host/host.cpp
+++ b/host/host.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 
 #include "experimental/xrt_kernel.h"
-#include "experimental/xrt_graph.h"
 #include "experimental/xrt_device.h"
 #include "experimental/xrt_bo.h"
 
@@ -33,65 +32,33 @@ static std::vector<float> read_file_to_vector(const std::string& filename, int s
   return data;
 }
 
-// Build weight and bias packets for the aieml graph.
-static std::vector<std::uint32_t> build_weights_aieml(const std::string& base_path) {
+// Send a packet through the switch and demux kernels and print its values.
+static void send_packet(xrt::device& device,
+                        xrt::kernel& switch_kernel,
+                        xrt::kernel& demux_kernel,
+                        const std::vector<float>& data,
+                        std::uint8_t bus_id,
+                        DataKind kind) {
   std::vector<std::uint32_t> words;
+  append_packet(words, data, bus_id, kind);
 
-  auto w0 = read_file_to_vector(base_path + "/" + EMBED_DENSE0_WEIGHTS,
-                                EMBED_DENSE0_WEIGHTS_SIZE);
-  append_packet(words, w0, bus::WEIGHTS0, KIND_WEIGHT);
-
-  auto w1a = read_file_to_vector(base_path + "/" +
-                                 EMBED_DENSE1_WEIGHTS_PREFIX + std::string("0.txt"),
-                                 EMBED_DENSE1_WEIGHTS_PART_SIZE);
-  append_packet(words, w1a, bus::WEIGHTS1_A, KIND_WEIGHT);
-
-  auto w1b = read_file_to_vector(base_path + "/" +
-                                 EMBED_DENSE1_WEIGHTS_PREFIX + std::string("1.txt"),
-                                 EMBED_DENSE1_WEIGHTS_PART_SIZE);
-  append_packet(words, w1b, bus::WEIGHTS1_B, KIND_WEIGHT);
-
-  auto b0 = read_file_to_vector(base_path + "/" + EMBED_DENSE0_BIAS,
-                                EMBED_DENSE0_BIAS_SIZE);
-  append_packet(words, b0, bus::BIAS0, KIND_BIAS);
-
-  auto b1 = read_file_to_vector(base_path + "/" + EMBED_DENSE1_BIAS,
-                                EMBED_DENSE1_BIAS_SIZE);
-  append_packet(words, b1, bus::BIAS1, KIND_BIAS);
-
-  return words;
-}
-
-// Stream pre-built packets through the switch and demux kernels.
-static void preload_weights_aieml(xrt::device& device,
-                                  xrt::kernel& switch_kernel,
-                                  xrt::kernel& demux_kernel,
-                                  const std::vector<std::uint32_t>& words) {
   xrt::bo bo(device, words.size() * sizeof(std::uint32_t), xrt::bo::flags::normal, 0);
   bo.write(words.data(), words.size() * sizeof(std::uint32_t), 0);
   bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 
-  std::size_t idx = 0;
-  while (idx < words.size()) {
-    std::uint32_t len = words[idx + 1];
-    std::size_t packet_words = 4 + static_cast<std::size_t>(len);
+  auto demux_run = xrt::run(demux_kernel);
+  demux_run.start();
 
-    if (idx + packet_words > words.size()) {
-      throw std::runtime_error("Packet length exceeds buffer size");
-    }
+  auto run = xrt::run(switch_kernel);
+  run.set_arg(0, bo);
+  run.set_arg(2, words.size());
+  run.start();
+  run.wait();
 
-    auto demux_run = xrt::run(demux_kernel);
-    demux_run.start();
+  demux_run.wait();
 
-    auto run = xrt::run(switch_kernel);
-    run.set_arg(0, bo, idx * sizeof(std::uint32_t));
-    run.set_arg(2, packet_words);
-    run.start();
-    run.wait();
-
-    demux_run.wait();
-    idx += packet_words;
-  }
+  for (float f : data)
+    std::cout << f << '\n';
 }
 
 int main(int argc, char** argv) {
@@ -108,87 +75,34 @@ int main(int argc, char** argv) {
     xrt::xclbin xclbin(xclbinFilename);
     auto uuid = device.load_xclbin(xclbin);
 
-    auto weight_words = build_weights_aieml(base_path);
-
-    // Build packetised input buffer
-    auto input_data = read_file_to_vector(base_path + "/" + EMBED_INPUT_DATA,
-                                          EMBED_DENSE0_INPUT_SIZE);
-    std::vector<std::uint32_t> input_words;
-  append_packet(input_words, input_data, bus::DIN, KIND_INPUT);
-
-    std::uint32_t in_len = input_words[1];
-    if (input_words.size() < 4 + static_cast<std::size_t>(in_len)) {
-      throw std::runtime_error("Input packet length exceeds buffer size");
-    }
-
-    xrt::bo input_bo(device, input_words.size() * sizeof(std::uint32_t), xrt::bo::flags::normal, 0);
-    input_bo.write(input_words.data(), input_words.size() * sizeof(std::uint32_t), 0);
-    input_bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
-
-    xrt::bo output_buf(device, EMBED_FINAL_OUTPUT_SIZE * sizeof(float), xrt::bo::flags::normal, 0);
-
-    // Kernel handles
     xrt::kernel switch_kernel(device, uuid, "switch_mm2s_pl:{mm2s_switch}");
     xrt::kernel demux_kernel(device, uuid, "demux_8_pl:{demux}");
-    xrt::kernel relu_kernel(device, uuid, "leaky_relu_pl:{relu}");
-    xrt::kernel relu2_kernel(device, uuid, "leaky_relu_pl:{relu2}");
-    xrt::kernel splitter_kernel(device, uuid, "leaky_splitter_pl:{splitter}");
-    xrt::kernel s2mm_kernel(device, uuid, "s2mm_pl:{s2mm_out}");
-    xrt::graph  aie_graph(device, uuid, "g");
 
-    // Initialize AI Engine graph before any data movement
-    aie_graph.init();
+    auto din = read_file_to_vector(base_path + "/" + EMBED_INPUT_DATA,
+                                   EMBED_DENSE0_INPUT_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, din, bus::DIN, KIND_INPUT);
 
-    auto s2mm_run = xrt::run(s2mm_kernel);
-    s2mm_run.set_arg(1, output_buf);
-    s2mm_run.set_arg(2, EMBED_FINAL_OUTPUT_SIZE);
-    s2mm_run.start();
+    auto w0 = read_file_to_vector(base_path + "/" + EMBED_DENSE0_WEIGHTS,
+                                  EMBED_DENSE0_WEIGHTS_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, w0, bus::WEIGHTS0, KIND_WEIGHT);
 
-    auto relu_run = xrt::run(relu_kernel);
-    relu_run.set_arg(3, HIDDEN_SIZE);
-    relu_run.start();
+    auto w1a = read_file_to_vector(base_path + "/" +
+                                   EMBED_DENSE1_WEIGHTS_PREFIX + std::string("0.txt"),
+                                   EMBED_DENSE1_WEIGHTS_PART_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, w1a, bus::WEIGHTS1_A, KIND_WEIGHT);
 
-    auto relu2_run = xrt::run(relu2_kernel);
-    relu2_run.set_arg(3, HIDDEN_SIZE);
-    relu2_run.start();
+    auto w1b = read_file_to_vector(base_path + "/" +
+                                   EMBED_DENSE1_WEIGHTS_PREFIX + std::string("1.txt"),
+                                   EMBED_DENSE1_WEIGHTS_PART_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, w1b, bus::WEIGHTS1_B, KIND_WEIGHT);
 
-    auto split_run = xrt::run(splitter_kernel);
-    split_run.start();
+    auto b0 = read_file_to_vector(base_path + "/" + EMBED_DENSE0_BIAS,
+                                  EMBED_DENSE0_BIAS_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, b0, bus::BIAS0, KIND_BIAS);
 
-    // Preload weights and biases before starting the graph
-    preload_weights_aieml(device, switch_kernel, demux_kernel, weight_words);
-
-    // Run AIE graph
-    aie_graph.run(1);
-
-    // Stream input data once the graph is running
-    auto demux_run = xrt::run(demux_kernel);
-    demux_run.start();
-
-    auto input_run = xrt::run(switch_kernel);
-    input_run.set_arg(0, input_bo);
-    input_run.set_arg(2, input_words.size());
-    input_run.start();
-
-    input_run.wait();
-    aie_graph.wait();
-    aie_graph.end();
-    s2mm_run.wait();
-    relu_run.wait();
-    relu2_run.wait();
-    split_run.wait();
-    demux_run.wait();
-
-    // Retrieve results
-    std::vector<float> host_output_data(EMBED_FINAL_OUTPUT_SIZE);
-    output_buf.sync(XCL_BO_SYNC_BO_FROM_DEVICE);
-    output_buf.read(host_output_data.data());
-
-    std::ofstream out(base_path + "/" + EMBED_HOST_OUTPUT);
-    for (int i = 0; i < EMBED_FINAL_OUTPUT_SIZE; ++i) {
-      std::cout << host_output_data[i] << '\n';
-      out << host_output_data[i] << '\n';
-    }
+    auto b1 = read_file_to_vector(base_path + "/" + EMBED_DENSE1_BIAS,
+                                  EMBED_DENSE1_BIAS_SIZE);
+    send_packet(device, switch_kernel, demux_kernel, b1, bus::BIAS1, KIND_BIAS);
 
   } catch (const std::exception& e) {
     std::cerr << "ERROR: " << e.what() << std::endl;
@@ -197,4 +111,3 @@ int main(int argc, char** argv) {
 
   return 0;
 }
-


### PR DESCRIPTION
## Summary
- Strip graph initialization and extra kernels, leaving only `switch_mm2s_pl` and `demux_8_pl`
- Build and send packets sequentially for input, weights, and biases while printing streamed values
- Simplify host Makefile to compile just the new `host.cpp`

## Testing
- `cd host && make clean && make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ade49e660c83208237e6cd264483ca