### PR TITLE
Use sample data in HLS tests and update project scripts

### DIFF
--- a/host/host_app_test.cpp
+++ b/host/host_app_test.cpp
@@ -1,0 +1,28 @@
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include "weights_bus.hpp"
+#include "../pl/bus_ids.hpp"
+
+static std::vector<float> read_file_to_vector(const std::string& fn, int count) {
+  std::vector<float> vals;
+  std::ifstream file(fn);
+  float v;
+  for (int i = 0; i < count && (file >> v); ++i)
+    vals.push_back(v);
+  return vals;
+}
+
+int main() {
+  auto data = read_file_to_vector("data/solver_0_input_part0.txt", 3);
+  std::vector<std::uint32_t> words;
+  append_packet(words, data, bus::DIN, KIND_INPUT);
+  for (float f : data)
+    std::cout << f << "\n";
+  std::cout << "Words: " << words.size() << std::endl;
+  assert(words.size() == 4 + data.size());
+  return 0;
+}

--- a/pl/demux_8_project.tcl
+++ b/pl/demux_8_project.tcl
@@ -10,7 +10,6 @@ set part_name   "xcve2802-vsvh1760-2MP-e-S"
 set project_name "${kernel_name}_hls"
 set top_function "${kernel_name}_pl"
 set kernel_file  "src/${kernel_name}_pl.cpp"
-set tb_file      "src/${kernel_name}_test.cpp"
 
 # --- Step 3: Command Handling ---
 if {$argc > 0} {
@@ -27,7 +26,7 @@ set_top $top_function
 
 # Add your project's specific source files from src/
 add_files $kernel_file
-add_files -tb $tb_file
+add_files -tb src/demux_8_test.cpp
 add_files -tb ../data/
 
 # Use the -flow_target vitis flag for correct XO generation

--- a/pl/src/demux_8_test.cpp
+++ b/pl/src/demux_8_test.cpp
@@ -1,80 +1,82 @@
 #include <ap_axi_sdata.h>
 #include <ap_int.h>
 #include <cassert>
+#include <cstring>
+#include <fstream>
 #include <hls_stream.h>
 #include <iostream>
+#include <vector>
+
+#include "../bus_ids.hpp"
 
 // axis_t definition matches demux_8_pl.cpp
-typedef ap_axiu<32, 1, 1, 8> axis_t; // data,user,id,dest
+using axis_t = ap_axiu<32,1,1,8>; // data,user,id,dest
 
-extern "C" void demux_8_pl(hls::stream<axis_t> &in, hls::stream<axis_t> &out0,
-                         hls::stream<axis_t> &out1, hls::stream<axis_t> &out2,
-                         hls::stream<axis_t> &out3, hls::stream<axis_t> &out4,
-                         hls::stream<axis_t> &out5, hls::stream<axis_t> &out6,
-                         hls::stream<axis_t> &out7, unsigned int word_count);
+extern "C" void demux_8_pl(hls::stream<axis_t>& in,
+                            hls::stream<axis_t>& out0,
+                            hls::stream<axis_t>& out1,
+                            hls::stream<axis_t>& out2,
+                            hls::stream<axis_t>& out3,
+                            hls::stream<axis_t>& out4,
+                            hls::stream<axis_t>& out5,
+                            hls::stream<axis_t>& out6,
+                            hls::stream<axis_t>& out7);
 
-int main() {
-  hls::stream<axis_t> in;
-  hls::stream<axis_t> out0, out1, out2, out3, out4, out5, out6, out7;
-  const int packet_len = 3;
-  const int NUM_BEATS = packet_len * 2;
+static std::vector<ap_uint<32>> load_data(const std::string& fn, int count) {
+  std::vector<ap_uint<32>> words;
+  std::ifstream file(fn);
+  float f;
+  for (int i = 0; i < count && (file >> f); ++i) {
+    ap_uint<32> w;
+    std::memcpy(&w, &f, sizeof(float));
+    words.push_back(w);
+  }
+  return words;
+}
 
-  // Preload input stream with NUM_BEATS beats
-  for (int i = 0; i < NUM_BEATS; ++i) {
-    axis_t t;
+static bool run_packet(const std::vector<ap_uint<32>>& data, ap_uint<8> dest) {
+  hls::stream<axis_t> in, out0, out1, out2, out3, out4, out5, out6, out7;
+
+  for (size_t i = 0; i < data.size(); ++i) {
+    axis_t t{};
+    t.data = data[i];
     t.keep = -1;
-    t.id   = 0;
-    t.user = 0;
-    if (i < packet_len) {
-      t.data = 0x10 + i;
-      t.dest = 3;
-      t.last = (i == packet_len - 1);
-    } else {
-      int j = i - packet_len;
-      t.data = 0x20 + j;
-      t.dest = 7;
-      t.last = (i == NUM_BEATS - 1);
-    }
+    t.strb = -1;
+    t.dest = dest;
+    t.last = (i == data.size() - 1);
     in.write(t);
   }
 
-  demux_8_pl(in, out0, out1, out2, out3, out4, out5, out6, out7, NUM_BEATS);
+  demux_8_pl(in, out0, out1, out2, out3, out4, out5, out6, out7);
 
+  hls::stream<axis_t>* outs[8] = {&out0,&out1,&out2,&out3,&out4,&out5,&out6,&out7};
   bool pass = true;
 
-  // Check output 3
-  for (int i = 0; i < packet_len; ++i) {
-    assert(!out3.empty());
-    axis_t v = out3.read();
-    bool last = (i == packet_len - 1);
-    if (v.data != (ap_uint<32>)(0x10 + i) || v.last != last)
-      pass = false;
-    assert(v.dest == 0);
-  }
-  if (!out3.empty())
-    pass = false;
-
-  // Check output 7
-  for (int i = 0; i < packet_len; ++i) {
-    assert(!out7.empty());
-    axis_t v = out7.read();
-    bool last = (i == packet_len - 1);
-    if (v.data != (ap_uint<32>)(0x20 + i) || v.last != last)
-      pass = false;
-    assert(v.dest == 0);
-  }
-  if (!out7.empty())
-    pass = false;
-
-  // Other outputs should be empty
-  hls::stream<axis_t> *outs[8] = {&out0, &out1, &out2, &out3,
-                                  &out4, &out5, &out6, &out7};
   for (int i = 0; i < 8; ++i) {
-    if (i == 3 || i == 7)
-      continue;
-    if (!outs[i]->empty())
-      pass = false;
+    if (i == dest) {
+      for (size_t j = 0; j < data.size(); ++j) {
+        assert(!outs[i]->empty());
+        axis_t v = outs[i]->read();
+        bool last = (j == data.size() - 1);
+        if (v.data != data[j] || v.last != last)
+          pass = false;
+        assert(v.dest == 0);
+      }
+      if (!outs[i]->empty())
+        pass = false;
+    } else {
+      if (!outs[i]->empty())
+        pass = false;
+    }
   }
+  return pass;
+}
+
+int main() {
+  bool pass = true;
+  pass &= run_packet(load_data("solver_0_input_part0.txt", 3), bus::DIN);
+  pass &= run_packet(load_data("solver_0_dense_0_weights_part0.txt", 3), bus::WEIGHTS0);
+  pass &= run_packet(load_data("solver_0_dense_0_bias.txt", 2), bus::BIAS0);
 
   if (pass) {
     std::cout << "Test PASSED" << std::endl;

--- a/pl/src/switch_mm2s_test.cpp
+++ b/pl/src/switch_mm2s_test.cpp
@@ -1,66 +1,125 @@
-#include <iostream>
-#include <ap_int.h>
-#include <hls_stream.h>
 #include <ap_axi_sdata.h>
+#include <ap_int.h>
 #include <cassert>
+#include <cstring>
+#include <fstream>
+#include <hls_stream.h>
+#include <iostream>
+#include <vector>
+
 #include "../bus_ids.hpp"
 
 // axis_t definition matches switch_mm2s_pl.cpp
-typedef ap_axiu<32,1,1,8> axis_t; // data,user,id,dest
+using axis_t = ap_axiu<32,1,1,8>; // data,user,id,dest
 
 #ifndef MEM_DEPTH
 #define MEM_DEPTH 1024
 #endif
 
 extern "C" void switch_mm2s_pl(const ap_uint<32>* in,
-                              hls::stream<axis_t>& out,
-                              uint32_t total_words);
+                                hls::stream<axis_t>& out,
+                                uint32_t total_words);
+extern "C" void demux_8_pl(hls::stream<axis_t>& in,
+                            hls::stream<axis_t>& out0,
+                            hls::stream<axis_t>& out1,
+                            hls::stream<axis_t>& out2,
+                            hls::stream<axis_t>& out3,
+                            hls::stream<axis_t>& out4,
+                            hls::stream<axis_t>& out5,
+                            hls::stream<axis_t>& out6,
+                            hls::stream<axis_t>& out7);
 
-int main() {
-    const ap_uint<8> part = 1;
-    const ap_uint<8> kind = 2;
-    const ap_uint<8> bus_id = bus::DIN;
-    const int payload_len = 3;
+enum DataKind : ap_uint<8> { KIND_INPUT=0, KIND_WEIGHT=1, KIND_BIAS=2 };
 
-    ap_uint<32> payload[payload_len] = {0xdeadbeef, 0xcafebabe, 0x12345678};
+struct WeightsHdr {
+  ap_uint<32> ctrl;
+  ap_uint<32> len;
+  ap_uint<32> r0;
+  ap_uint<32> r1;
+  WeightsHdr(ap_uint<8> bus_id, DataKind kind, ap_uint<32> length_words)
+      : ctrl((0u << 24) | (ap_uint<32>(kind) << 16) | ap_uint<32>(bus_id)),
+        len(length_words), r0(0), r1(0) {}
+};
 
-    const int total_words = 4 + payload_len;
-    // ap_uint<32> mem[total_words];
-    static ap_uint<32> mem[MEM_DEPTH] = {0};  // must be >= pragma depth
-
-    mem[0] = (part << 24) | (kind << 16) | (bus_id);
-    mem[1] = payload_len;
-    mem[2] = 0;
-    mem[3] = 0;
-    for (int i = 0; i < payload_len; ++i) {
-        mem[4 + i] = payload[i];
-    }
-
-    hls::stream<axis_t> out;
-    switch_mm2s_pl(mem, out, total_words);
-
-    bool pass = true;
-    for (int i = 0; i < payload_len; ++i) {
-        assert(!out.empty());
-        axis_t val = out.read();
-        bool last = (i == payload_len - 1);
-        if (val.data != payload[i] || val.dest != bus_id || val.last != last) {
-            pass = false;
-        }
-        assert(val.data == payload[i]);
-        assert(val.dest == bus_id);
-        assert(val.last == last);
-    }
-    if (!out.empty()) {
-        pass = false;
-    }
-
-    if (pass) {
-        std::cout << "Test PASSED" << std::endl;
-        return 0;
-    } else {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
+static std::vector<ap_uint<32>> load_data(const std::string& fn, int count) {
+  std::vector<ap_uint<32>> words;
+  std::ifstream file(fn);
+  float f;
+  for (int i = 0; i < count && (file >> f); ++i) {
+    ap_uint<32> w;
+    std::memcpy(&w, &f, sizeof(float));
+    words.push_back(w);
+  }
+  return words;
 }
 
+static void append_packet(std::vector<ap_uint<32>>& dst,
+                          const std::vector<ap_uint<32>>& data,
+                          ap_uint<8> bus_id,
+                          DataKind kind) {
+  WeightsHdr h(bus_id, kind, data.size());
+  dst.push_back(h.ctrl);
+  dst.push_back(h.len);
+  dst.push_back(h.r0);
+  dst.push_back(h.r1);
+  for (auto w : data)
+    dst.push_back(w);
+}
+
+static bool check_stream(hls::stream<axis_t>& s,
+                         const std::vector<ap_uint<32>>& exp) {
+  for (size_t i = 0; i < exp.size(); ++i) {
+    assert(!s.empty());
+    axis_t v = s.read();
+    bool last = (i == exp.size() - 1);
+    if (v.data != exp[i] || v.last != last)
+      return false;
+    assert(v.dest == 0);
+  }
+  return s.empty();
+}
+
+int main() {
+  auto din = load_data("solver_0_input_part0.txt", 3);
+  auto w0  = load_data("solver_0_dense_0_weights_part0.txt", 3);
+  auto b0  = load_data("solver_0_dense_0_bias.txt", 2);
+
+  std::vector<ap_uint<32>> words;
+  append_packet(words, din, bus::DIN,      KIND_INPUT);
+  append_packet(words, w0,  bus::WEIGHTS0, KIND_WEIGHT);
+  append_packet(words, b0,  bus::BIAS0,    KIND_BIAS);
+
+  const uint32_t total_words = words.size();
+  static ap_uint<32> mem[MEM_DEPTH] = {0};
+  for (uint32_t i = 0; i < total_words; ++i)
+    mem[i] = words[i];
+
+  hls::stream<axis_t> mm2s_out;
+  switch_mm2s_pl(mem, mm2s_out, total_words);
+
+  bool pass = true;
+  hls::stream<axis_t> out0, out1, out2, out3, out4, out5, out6, out7;
+
+  demux_8_pl(mm2s_out, out0, out1, out2, out3, out4, out5, out6, out7);
+  pass &= check_stream(out0, din);
+  pass &= out1.empty() && out2.empty() && out3.empty() && out4.empty() &&
+          out5.empty() && out6.empty() && out7.empty();
+
+  demux_8_pl(mm2s_out, out0, out1, out2, out3, out4, out5, out6, out7);
+  pass &= check_stream(out1, w0);
+  pass &= out0.empty() && out2.empty() && out3.empty() && out4.empty() &&
+          out5.empty() && out6.empty() && out7.empty();
+
+  demux_8_pl(mm2s_out, out0, out1, out2, out3, out4, out5, out6, out7);
+  pass &= check_stream(out4, b0);
+  pass &= out0.empty() && out1.empty() && out2.empty() && out3.empty() &&
+          out5.empty() && out6.empty() && out7.empty();
+
+  if (pass && mm2s_out.empty()) {
+    std::cout << "Test PASSED" << std::endl;
+    return 0;
+  } else {
+    std::cout << "Test FAILED" << std::endl;
+    return 1;
+  }
+}

--- a/pl/switch_mm2s_project.tcl
+++ b/pl/switch_mm2s_project.tcl
@@ -10,7 +10,6 @@ set part_name   "xcve2802-vsvh1760-2MP-e-S"
 set project_name "${kernel_name}_hls"
 set top_function "${kernel_name}_pl"
 set kernel_file  "src/${kernel_name}_pl.cpp"
-set tb_file      "src/${kernel_name}_test.cpp"
 
 # --- Step 3: Command Handling ---
 if {$argc > 0} {
@@ -27,7 +26,7 @@ set_top $top_function
 
 # Add your project's specific source files from src/
 add_files $kernel_file
-add_files -tb $tb_file
+add_files -tb src/switch_mm2s_test.cpp
 add_files -tb ../data/
 
 # Use the -flow_target vitis flag for correct XO generation


### PR DESCRIPTION
## Summary
- Rewrite `demux_8_test` and `switch_mm2s_test` to pull sample DIN/weight/bias data from `data/` and check demux routing
- Point HLS project tcl scripts at the trimmed testbenches
- Add a small host-side unit test that packages sample input data

## Testing
- `g++ host/host_app_test.cpp -Ihost -Ipl -o /tmp/host_app_test && /tmp/host_app_test`
- `make -C pl sim TARGET=hw_emu` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ade8808f7883208c3f3a5020a4dc37