### PR TITLE
Adjust host Makefile data path and includes

### DIFF
--- a/host/Makefile
+++ b/host/Makefile
@@ -3,8 +3,8 @@
 # Toolchain and paths
 SYSROOT ?= /opt/petalinux/2024.2/sysroots/cortexa72-cortexa53-xilinx-linux
 CXX     := aarch64-linux-gnu-g++
-# Default data directory lives one level above the project root
-DATA_DIR ?= $(abspath ../../data)
+# Default data directory within the project root (can be overridden)
+DATA_DIR ?= $(abspath ../data)
 export DATA_DIR
 
 # Sources and targets
@@ -16,7 +16,7 @@ CXXFLAGS ?= -Wall -std=c++17 -Wno-int-to-pointer-cast \
         --sysroot=$(SYSROOT) \
         -I$(SYSROOT)/usr/include/xrt \
         -I$(SYSROOT)/usr/include \
-        -I./ -I../common -I/aietools/include -I/include \
+        -I./ -I../common \
         -DDATA_DIR='"$(DATA_DIR)"'
 
 LDFLAGS ?= --sysroot=$(SYSROOT) \


### PR DESCRIPTION
## Summary
- point host build's DATA_DIR default to repository data folder
- drop unused /aietools and root include paths from host CXXFLAGS

## Testing
- `make -C host clean all` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adee524a408320a1445fedf520f9e8