### PR TITLE
Use DATA_DIR for host data path

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
   }
 
   const std::string xclbinFilename = argv[1];
-  const std::string base_path = "./data";
+  const std::string base_path = DATA_DIR;
 
   try {
     xrt::device device(0);


### PR DESCRIPTION
## Summary
- honor build-time DATA_DIR in host application by removing hardcoded ./data path

## Testing
- `cd host && make clean && make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adee22d7d0832081f353ffab75792a