### PR TITLE
Cleanup unused variables in switch_mm2s kernel

### DIFF
--- a/pl/src/switch_mm2s_pl.cpp
+++ b/pl/src/switch_mm2s_pl.cpp
@@ -33,16 +33,15 @@ void switch_mm2s_pl(const ap_uint<32>* in,      // AXI4-MM (DDR)
     ap_uint<32> w1 = in[idx + 1];
     idx += WORDS_PER_HDR;
 
-    ap_uint<8>  part    = w0.range(31,24);
-    ap_uint<8>  kind    = w0.range(23,16);
-    ap_uint<8>  bus_id  = w0.range(7,0);
-    uint32_t    len_words= (uint32_t)w1;
+    ap_uint<8>  bus_id   = w0.range(7,0);
+    uint32_t    len_words = (uint32_t)w1;
 
     // Guard against malformed packets that claim more words than remain
     if (idx + len_words > total_words) {
-      assert(idx + len_words <= total_words);
+      // Truncate to the remaining words
       len_words = total_words - idx;
     }
+    assert(idx + len_words <= total_words);
 
     // Stream payload
     for (uint32_t i = 0; i < len_words; ++i) {


### PR DESCRIPTION
## Summary
- remove unused `part` and `kind` header fields
- streamline length guard and move assert outside

## Testing
- `g++ -std=c++17 pl/src/switch_mm2s_test.cpp pl/src/switch_mm2s_pl.cpp pl/src/demux_8_pl.cpp -Ipl/src -Ipl -o /tmp/test_switch_mm2s` *(fails: ap_axi_sdata.h: No such file or directory)*
- `make -C pl sim TARGET=sw_emu KERNELS=switch_mm2s` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adef5fdcec8320963e08a882c975ec