### PR TITLE
Use common data path constants in tests

### DIFF
--- a/host/host_app_test.cpp
+++ b/host/host_app_test.cpp
@@ -3,9 +3,11 @@
 #include <fstream>
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "weights_bus.hpp"
 #include "../pl/bus_ids.hpp"
+#include "../common/data_paths.h"
 
 static std::vector<float> read_file_to_vector(const std::string& fn, int count) {
   std::vector<float> vals;
@@ -17,7 +19,7 @@ static std::vector<float> read_file_to_vector(const std::string& fn, int count) 
 }
 
 int main() {
-  auto data = read_file_to_vector("data/solver_0_input_part0.txt", 3);
+  auto data = read_file_to_vector(std::string(DATA_DIR) + "/" + EMBED_INPUT_DATA, 3);
   std::vector<std::uint32_t> words;
   append_packet(words, data, bus::DIN, KIND_INPUT);
   for (float f : data)

--- a/pl/src/demux_8_test.cpp
+++ b/pl/src/demux_8_test.cpp
@@ -6,8 +6,10 @@
 #include <hls_stream.h>
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "../bus_ids.hpp"
+#include "../../common/data_paths.h"
 
 // axis_t definition matches demux_8_pl.cpp
 using axis_t = ap_axiu<32,1,1,8>; // data,user,id,dest
@@ -74,9 +76,9 @@ static bool run_packet(const std::vector<ap_uint<32>>& data, ap_uint<8> dest) {
 
 int main() {
   bool pass = true;
-  pass &= run_packet(load_data("solver_0_input_part0.txt", 3), bus::DIN);
-  pass &= run_packet(load_data("solver_0_dense_0_weights_part0.txt", 3), bus::WEIGHTS0);
-  pass &= run_packet(load_data("solver_0_dense_0_bias.txt", 2), bus::BIAS0);
+  pass &= run_packet(load_data(std::string(DATA_DIR) + "/" + EMBED_INPUT_DATA, 3), bus::DIN);
+  pass &= run_packet(load_data(std::string(DATA_DIR) + "/" + EMBED_DENSE0_WEIGHTS, 3), bus::WEIGHTS0);
+  pass &= run_packet(load_data(std::string(DATA_DIR) + "/" + EMBED_DENSE0_BIAS, 2), bus::BIAS0);
 
   if (pass) {
     std::cout << "Test PASSED" << std::endl;

--- a/pl/src/switch_mm2s_test.cpp
+++ b/pl/src/switch_mm2s_test.cpp
@@ -6,8 +6,10 @@
 #include <hls_stream.h>
 #include <iostream>
 #include <vector>
+#include <string>
 
 #include "../bus_ids.hpp"
+#include "../../common/data_paths.h"
 
 // axis_t definition matches switch_mm2s_pl.cpp
 using axis_t = ap_axiu<32,1,1,8>; // data,user,id,dest
@@ -80,9 +82,9 @@ static bool check_stream(hls::stream<axis_t>& s,
 }
 
 int main() {
-  auto din = load_data("solver_0_input_part0.txt", 3);
-  auto w0  = load_data("solver_0_dense_0_weights_part0.txt", 3);
-  auto b0  = load_data("solver_0_dense_0_bias.txt", 2);
+  auto din = load_data(std::string(DATA_DIR) + "/" + EMBED_INPUT_DATA, 3);
+  auto w0  = load_data(std::string(DATA_DIR) + "/" + EMBED_DENSE0_WEIGHTS, 3);
+  auto b0  = load_data(std::string(DATA_DIR) + "/" + EMBED_DENSE0_BIAS, 2);
 
   std::vector<ap_uint<32>> words;
   append_packet(words, din, bus::DIN,      KIND_INPUT);


### PR DESCRIPTION
## Summary
- include common/data_paths.h in host and PL tests
- replace hardcoded solver_0_* file names with EMBED_* constants and DATA_DIR

## Testing
- `g++ host/host_app_test.cpp -Ihost -Icommon -std=c++17 -o /tmp/host_app_test`
- `DATA_DIR=data /tmp/host_app_test`
- `g++ pl/src/switch_mm2s_test.cpp -Ipl -Icommon -std=c++17 -o /tmp/switch_mm2s_test` *(fails: ap_axi_sdata.h missing)*
- `g++ pl/src/demux_8_test.cpp -Ipl -Icommon -std=c++17 -o /tmp/demux_8_test` *(fails: ap_axi_sdata.h missing)*


------
https://chatgpt.com/codex/tasks/task_e_68adf01311688320b0dfbde4bf4ba263