### PR TITLE
Use kernel group ID for buffer allocation in host app

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -42,7 +42,7 @@ static void send_packet(xrt::device& device,
   std::vector<std::uint32_t> words;
   append_packet(words, data, bus_id, kind);
 
-  xrt::bo bo(device, words.size() * sizeof(std::uint32_t), xrt::bo::flags::normal, 0);
+  xrt::bo bo(device, words.size() * sizeof(std::uint32_t), xrt::bo::flags::normal, switch_kernel.group_id(0));
   bo.write(words.data(), words.size() * sizeof(std::uint32_t), 0);
   bo.sync(XCL_BO_SYNC_BO_TO_DEVICE);
 


### PR DESCRIPTION
## Summary
- Replace hard-coded 0 with `switch_kernel.group_id(0)` when creating `xrt::bo` so buffer allocation uses the proper kernel group.

## Testing
- `make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adf1146be883208922d45878d9ac3f