### PR TITLE
Use data path macros in s2mm test bench

### DIFF
--- a/pl/src/s2mm_test.cpp
+++ b/pl/src/s2mm_test.cpp
@@ -4,7 +4,7 @@
 #include <hls_stream.h>
 #include <ap_axi_sdata.h>
 #include "../../common/data_paths.h"
-#include <filesystem>
+#include <string>
 
 typedef float data_t;
 typedef hls::axis<data_t, 0, 0, 0> axis_t;
@@ -18,11 +18,10 @@ int main() {
     std::vector<data_t> golden_data;
     golden_data.reserve(SIZE);
     
-    std::string filepath = "/home/synthara/VersalPrjs/LDRD/rtda_demo/data/embed_dense_0_bias.txt";
-
+    std::string filepath = std::string(DATA_DIR) + "/" + EMBED_DENSE0_BIAS;
     std::ifstream fin(filepath);
     if (!fin.is_open()) {
-        std::cerr << "ERROR: Cannot open hardcoded file: " << filepath << std::endl;
+        std::cerr << "ERROR: Cannot open file: " << filepath << std::endl;
         return 1;
     }
 


### PR DESCRIPTION
## Summary
- Construct the testbench data file path from `DATA_DIR` and `EMBED_DENSE0_BIAS` using `std::string` instead of a hardcoded string.

## Testing
- `make sim TARGET=csim` *(fails: vitis_hls: not found)*
- `make kernels` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af42bf2914832088d2448bc8ae4622