### PR TITLE
Set absolute DATA_DIR for HLS sims

### DIFF
--- a/pl/Makefile
+++ b/pl/Makefile
@@ -5,6 +5,11 @@
 # ===================================================================
 VITIS_HLS ?= vitis_hls
 
+# Resolve data directory to an absolute path so simulations can locate input
+# files regardless of the working directory used by Vitis HLS.
+DATA_DIR ?= $(abspath ../data)
+export DATA_DIR
+
 # List of kernels (add more as needed)
 # KERNELS ?= mm2s leaky_relu leaky_splitter s2mm switch_mm2s demux_8
 KERNELS := s2mm switch_mm2s demux_8
@@ -35,6 +40,7 @@ kernels:
 .PHONY: sim
 sim:
 	@echo "--- Running Simulation for TARGET=$(TARGET) ---"
+	@echo "DATA_DIR=$(DATA_DIR)"
 ifneq ($(filter $(TARGET),hw hw_emu),)
 	for KERNEL in $(KERNELS); do \
 		echo "--- Running hw/hw_emu co-simulation for $$KERNEL ---"; \

--- a/pl/src/s2mm_test.cpp
+++ b/pl/src/s2mm_test.cpp
@@ -18,7 +18,9 @@ int main() {
     std::vector<data_t> golden_data;
     golden_data.reserve(SIZE);
     
-    std::string filepath = std::string(DATA_DIR) + "/" + EMBED_DENSE0_BIAS;
+    const char* data_dir = DATA_DIR;
+    std::cout << "DATA_DIR resolved to: " << data_dir << std::endl;
+    std::string filepath = std::string(data_dir) + "/" + EMBED_DENSE0_BIAS;
     std::ifstream fin(filepath);
     if (!fin.is_open()) {
         std::cerr << "ERROR: Cannot open file: " << filepath << std::endl;


### PR DESCRIPTION
## Summary
- Export absolute DATA_DIR in PL Makefile so HLS C- and co-sim find test data
- Resolve DATA_DIR in s2mm testbench with string concatenation (no `<filesystem>`) and log the path

## Testing
- `make sim TARGET=sw_emu` *(fails: vitis_hls: not found)*
- `make sim TARGET=hw_emu` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af43e5c40c8320b8df63608db524aa