### PR TITLE
docs: update PL kernel README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The design partitions work across three components of the Versal architecture:
   ```
 
   Valid graphs are `aieml`, `aieml2`, and `aieml3`.
-- **Programmable Logic (PL)** – supplies data‑mover kernels and two leaky ReLU units.
+- **Programmable Logic (PL)** – provides `switch_mm2s`, `s2mm`, and `demux_8` data‑mover kernels for streaming between DDR and the AI Engine.
 - **Host application** – runs on the processing system and orchestrates data movement and graph execution through XRT.
 
 All build instructions are split into component READMEs:

--- a/pl/README.md
+++ b/pl/README.md
@@ -3,12 +3,11 @@
 This directory contains several Vitis HLS kernels used to move and process data between DDR memory and the AI Engine graph.
 
 ## Available kernels
-- **mm2s_pl** – transfers `float` words from memory to an AXI4-Stream interface using an AXI master port and a simple pipeline loop.
-- **s2mm_pl** – reads data from an AXI4-Stream and writes it back to memory through an AXI master port.
-- **leaky_relu_pl** – leaky ReLU stage; the system instantiates two of these kernels.
-- **leaky_splitter_pl** – splits a single input stream into multiple cascaded outputs.
+- **switch_mm2s_pl** – memory‑to‑stream mover with a selectable source, allowing the host to switch between multiple input buffers at run time.
+- **s2mm_pl** – streams data from the AI Engine back to memory via an AXI master interface.
+- **demux_8_pl** – demultiplexes one input stream into eight independent AXI4‑Stream outputs for distribution to downstream kernels.
 
-Each kernel has a matching `*_test.cpp` file (for example, `mm2s_test.cpp`) used for functional validation.
+Each kernel has a matching `*_test.cpp` file (for example, `s2mm_test.cpp`) used for functional validation.
 
 Test benches reference file names from [`common/data_paths.h`](../common/data_paths.h)
 and honour the `DATA_DIR` environment variable, which lets you relocate the
@@ -17,10 +16,9 @@ text files used during simulation.
 ## Build scripts
 The top-level [Makefile](Makefile) orchestrates all kernel builds using the accompanying TCL scripts:
 
-- `mm2s_project.tcl`
+- `switch_mm2s_project.tcl`
 - `s2mm_project.tcl`
-- `leaky_relu_project.tcl`
-- `leaky_splitter_project.tcl`
+- `demux_8_project.tcl`
 
 The default target list can be overridden using the `KERNELS` variable. Useful commands:
 
@@ -35,7 +33,7 @@ make clean             # remove generated outputs
 Synthesis places exported XO/IP files in the `ip/` directory. When preparing a system build, copy or link the required `*.xo` into a build folder such as `build_hw_emu/` referenced by `system_project.yaml`.
 
 ## Integration with the system project
-The system project consumes the generated kernels via the `pl_kernels` component defined in [`system_project.yaml`](../system_project.yaml). After building, ensure the expected `.xo` files (e.g. `mm2s_8_128.xo`) reside in `pl/build_<target>/` so the link step can find them.
+The system project consumes the generated kernels via the `pl_kernels` component defined in [`system_project.yaml`](../system_project.yaml). After building, ensure the expected `.xo` files (for example, `switch_mm2s_8_128.xo` or `demux_8.xo`) reside in `pl/build_<target>/` so the link step can find them.
 
 ## Testing
 Run `make sim` or invoke `vitis_hls -f <kernel>_project.tcl csim` to execute the C++ test benches. These tests verify kernel functionality before synthesis.


### PR DESCRIPTION
## Summary
- document new `switch_mm2s`, `s2mm`, and `demux_8` programmable logic kernels
- clarify build scripts and integration details for updated kernels

## Testing
- `make -C pl sim TARGET=csim` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4cd7d62083208d4609a459ed08ad