### PR TITLE
docs: update PL kernels

### DIFF
--- a/pl/README.md
+++ b/pl/README.md
@@ -3,12 +3,11 @@
 This directory contains several Vitis HLS kernels used to move and process data between DDR memory and the AI Engine graph.
 
 ## Available kernels
-- **mm2s_pl** – transfers `float` words from memory to an AXI4-Stream interface using an AXI master port and a simple pipeline loop.
-- **s2mm_pl** – reads data from an AXI4-Stream and writes it back to memory through an AXI master port.
-- **leaky_relu_pl** – leaky ReLU stage; the system instantiates two of these kernels.
-- **leaky_splitter_pl** – splits a single input stream into multiple cascaded outputs.
+- **s2mm_pl** – writes stream data back to memory.
+- **switch_mm2s_pl** – routes memory segments to multiple streams based on `TDEST`.
+- **demux_8_pl** – demultiplexes a single input stream into eight outputs.
 
-Each kernel has a matching `*_test.cpp` file (for example, `mm2s_test.cpp`) used for functional validation.
+Each kernel has a matching `*_test.cpp` file (for example, `s2mm_test.cpp`) used for functional validation.
 
 Test benches reference file names from [`common/data_paths.h`](../common/data_paths.h)
 and honour the `DATA_DIR` environment variable, which lets you relocate the
@@ -17,10 +16,9 @@ text files used during simulation.
 ## Build scripts
 The top-level [Makefile](Makefile) orchestrates all kernel builds using the accompanying TCL scripts:
 
-- `mm2s_project.tcl`
 - `s2mm_project.tcl`
-- `leaky_relu_project.tcl`
-- `leaky_splitter_project.tcl`
+- `switch_mm2s_project.tcl`
+- `demux_8_project.tcl`
 
 The default target list can be overridden using the `KERNELS` variable. Useful commands:
 
@@ -35,7 +33,7 @@ make clean             # remove generated outputs
 Synthesis places exported XO/IP files in the `ip/` directory. When preparing a system build, copy or link the required `*.xo` into a build folder such as `build_hw_emu/` referenced by `system_project.yaml`.
 
 ## Integration with the system project
-The system project consumes the generated kernels via the `pl_kernels` component defined in [`system_project.yaml`](../system_project.yaml). After building, ensure the expected `.xo` files (e.g. `mm2s_8_128.xo`) reside in `pl/build_<target>/` so the link step can find them.
+The system project consumes the generated kernels via the `pl_kernels` component defined in [`system_project.yaml`](../system_project.yaml). After building, ensure the generated `.xo` files for these kernels (e.g. `s2mm_*.xo`, `switch_mm2s_*.xo`, `demux_8_*.xo`) reside in `pl/build_<target>/` so the link step can find them.
 
 ## Testing
 Run `make sim` or invoke `vitis_hls -f <kernel>_project.tcl csim` to execute the C++ test benches. These tests verify kernel functionality before synthesis.


### PR DESCRIPTION
## Summary
- document s2mm_pl, switch_mm2s_pl, and demux_8_pl kernels
- update Build scripts to reference current TCL projects
- drop legacy mm2s and leaky kernel references

## Testing
- `make -C pl sim TARGET=csim` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af508013888320ae3d32914eb79e78