### PR TITLE
docs: update system project README for new data-mover kernels

### DIFF
--- a/system_project/README.md
+++ b/system_project/README.md
@@ -5,8 +5,8 @@ The `system_project.yaml` file describes how the host application, AI Engine-ML 
 ## Components
 
 - **host_app** – Linux application running on the PS that manages buffer allocation, device control, and execution of the accelerated graph.
-- **aie_graph** – AI Engine-ML graph implementing dense1 and dense2; leaky ReLU stages run in the programmable logic.
-- **pl_kernels** – Precompiled data-mover and activation kernels (`mm2s_8_128.xo`, `s2mm_16_128.xo`, `s2mm_32_128.xo`, `leaky_relu.xo`, `leaky_splitter.xo`) that stream data between DDR and the AIE array.
+- **aie_graph** – AI Engine-ML graph implementing dense1 and dense2.
+- **pl_kernels** – Precompiled data-mover kernels (`s2mm_hls.xo`, `switch_mm2s_hls.xo`, `demux_8_hls.xo`) that stream data between DDR and the AIE array.
 - **hw_link_output** – The hardware linkage output (`design_hw_emu.xsa`) that ties the PS, PL, and AIE-ML domains into a single platform image.
 
 ## Building the System
@@ -30,7 +30,7 @@ The build produces a packaged `.xclbin` under `package.hw_emu/` ready for emulat
 |  Host (PS)  | <------------------> | PL Kernels  |
 +-------------+                      +-------------+
         |                                 |
-        | Streams via mm2s/s2mm           |
+        | Streams via switch_mm2s/demux_8/s2mm |
         v                                 v
       +-------------------------------------+
       |            AIE-ML Graph             |


### PR DESCRIPTION
## Summary
- document current data-mover kernels (s2mm, switch_mm2s, demux_8) in system project README
- drop obsolete leaky_relu and mm2s references
- note new switch_mm2s/demux_8/s2mm streaming path in architecture diagram

## Testing
- `make print_vars`

------
https://chatgpt.com/codex/tasks/task_e_68af50ed52788320828e17d8ead66a4d