### PR TITLE
Align kernel names in switch linker config with host expectations

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -1,18 +1,18 @@
 [connectivity]
 # Kernel instance counts and instance base names
-nk=switch_mm2s_pl:1:mm2s_switch
+nk=switch_mm2s_pl:1:switch_mm2s
 nk=demux_8_pl:1:demux
-nk=s2mm_pl:8:s2mm_1,s2mm_2,s2mm_3,s2mm_4,s2mm_5,s2mm_6,s2mm_7,s2mm_8
+nk=s2mm_pl:8:s2mm_0,s2mm_1,s2mm_2,s2mm_3,s2mm_4,s2mm_5,s2mm_6,s2mm_7
 
 # AXIS connections
-stream_connect=mm2s_switch.out:demux.in
+stream_connect=switch_mm2s.out:demux.in
 
-stream_connect=demux.out0:s2mm_1.s
-stream_connect=demux.out1:s2mm_2.s
-stream_connect=demux.out2:s2mm_3.s
-stream_connect=demux.out3:s2mm_4.s
-stream_connect=demux.out4:s2mm_5.s
-stream_connect=demux.out5:s2mm_6.s
-stream_connect=demux.out6:s2mm_7.s
-stream_connect=demux.out7:s2mm_8.s
+stream_connect=demux.out0:s2mm_0.s
+stream_connect=demux.out1:s2mm_1.s
+stream_connect=demux.out2:s2mm_2.s
+stream_connect=demux.out3:s2mm_3.s
+stream_connect=demux.out4:s2mm_4.s
+stream_connect=demux.out5:s2mm_5.s
+stream_connect=demux.out6:s2mm_6.s
+stream_connect=demux.out7:s2mm_7.s
 


### PR DESCRIPTION
## Summary
- update `nk` and stream connections in `linker_switch.cfg` to use `switch_mm2s` and `s2mm_0..7`

## Testing
- `make link TARGET=hw_emu` *(fails: vitis_hls: not found)*
- `make host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `./host/system_host package.hw_emu/system_hw_emu.xclbin` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68af6180c2e083208ec24ab84737c521