### PR TITLE
Align kernel argument indices for PL interaction

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -184,14 +184,14 @@ int main(int argc, char** argv) {
 
         // Start consumer kernels
         auto s2mm_run = xrt::run(s2mm_kernel);
-        s2mm_run.set_arg(1, output_buf);
-        s2mm_run.set_arg(2, cfg.output_size);
+        s2mm_run.set_arg(0, output_buf);
+        s2mm_run.set_arg(1, cfg.output_size);
         s2mm_run.start();
 
         std::vector<xrt::run> relu_runs;
         for (auto& k : relu_kernels) {
             auto r = xrt::run(k);
-            r.set_arg(3, cfg.relu_size);
+            r.set_arg(0, cfg.relu_size);
             r.start();
             relu_runs.push_back(std::move(r));
         }
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
             if (cfg.mm2s[i].preload) {
                 auto run = xrt::run(mm2s_kernels[i]);
                 run.set_arg(0, mm2s_bos[i]);
-                run.set_arg(2, cfg.mm2s[i].size);
+                run.set_arg(1, cfg.mm2s[i].size);
                 run.start();
                 run.wait();
             }
@@ -222,7 +222,7 @@ int main(int argc, char** argv) {
             if (!cfg.mm2s[i].preload) {
                 auto run = xrt::run(mm2s_kernels[i]);
                 run.set_arg(0, mm2s_bos[i]);
-                run.set_arg(2, cfg.mm2s[i].size);
+                run.set_arg(1, cfg.mm2s[i].size);
                 run.start();
                 mm2s_runs.push_back(std::move(run));
             }


### PR DESCRIPTION
## Summary
- Set s2mm output buffer and size arguments to indices 0 and 1
- Pass relu_size as first argument to leaky ReLU PL kernels
- Use argument index 1 for mm2s size in both preload and runtime phases

## Testing
- `make` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68afb83116fc8320b73be00e19ee5529