### PR TITLE
Map switch kernel ports to DDR

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -16,3 +16,13 @@ stream_connect=demux.out5:s2mm_5.s
 stream_connect=demux.out6:s2mm_6.s
 stream_connect=demux.out7:s2mm_7.s
 
+sp=s2mm_0.mem:DDR[0]
+sp=s2mm_1.mem:DDR[0]
+sp=s2mm_2.mem:DDR[0]
+sp=s2mm_3.mem:DDR[0]
+sp=s2mm_4.mem:DDR[0]
+sp=s2mm_5.mem:DDR[0]
+sp=s2mm_6.mem:DDR[0]
+sp=s2mm_7.mem:DDR[0]
+sp=switch_mm2s.in:DDR[0]
+


### PR DESCRIPTION
## Summary
- assign s2mm kernel memory ports and switch_mm2s input to DDR bank 0 for proper memory placement

## Testing
- `make link` *(fails: vitis_hls: not found)*
- `make host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make run` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b07a5da0b48320b2a6f7972094296d