### PR TITLE
Use LPDDR memory in link configuration

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -16,13 +16,13 @@ stream_connect=demux.out5:s2mm_5.s
 stream_connect=demux.out6:s2mm_6.s
 stream_connect=demux.out7:s2mm_7.s
 
-sp=s2mm_0.mem:DDR[0]
-sp=s2mm_1.mem:DDR[0]
-sp=s2mm_2.mem:DDR[0]
-sp=s2mm_3.mem:DDR[0]
-sp=s2mm_4.mem:DDR[0]
-sp=s2mm_5.mem:DDR[0]
-sp=s2mm_6.mem:DDR[0]
-sp=s2mm_7.mem:DDR[0]
-sp=switch_mm2s.in:DDR[0]
+sp=s2mm_0.mem:LPDDR[0]
+sp=s2mm_1.mem:LPDDR[0]
+sp=s2mm_2.mem:LPDDR[0]
+sp=s2mm_3.mem:LPDDR[0]
+sp=s2mm_4.mem:LPDDR[0]
+sp=s2mm_5.mem:LPDDR[0]
+sp=s2mm_6.mem:LPDDR[0]
+sp=s2mm_7.mem:LPDDR[0]
+sp=switch_mm2s.in:LPDDR[0]
 


### PR DESCRIPTION
## Summary
- Point switch and S2MM memory ports to LPDDR in linker configuration

## Testing
- `platforminfo /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm` *(fails: command not found)*
- `make link` *(fails: vitis_hls: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b07f605d8c8320b8afb946a46c14c7