### PR TITLE
Remove LPDDR memory bindings from switch linker configuration

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -16,13 +16,3 @@ stream_connect=demux.out5:s2mm_5.s
 stream_connect=demux.out6:s2mm_6.s
 stream_connect=demux.out7:s2mm_7.s
 
-sp=s2mm_0.mem:LPDDR[0]
-sp=s2mm_1.mem:LPDDR[0]
-sp=s2mm_2.mem:LPDDR[0]
-sp=s2mm_3.mem:LPDDR[0]
-sp=s2mm_4.mem:LPDDR[0]
-sp=s2mm_5.mem:LPDDR[0]
-sp=s2mm_6.mem:LPDDR[0]
-sp=s2mm_7.mem:LPDDR[0]
-sp=switch_mm2s.in:LPDDR[0]
-


### PR DESCRIPTION
## Summary
- remove LPDDR-specific `sp=` assignments from the switch linker config

## Testing
- `platforminfo --platform /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm` (command not found)
- `make link` (fails: vitis_hls not found)

------
https://chatgpt.com/codex/tasks/task_e_68b082f880ac8320998b8f9471bdc15d