### PR TITLE
Add DDR assignments to linker_switch.cfg

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -16,3 +16,14 @@ stream_connect=demux.out5:s2mm_5.s
 stream_connect=demux.out6:s2mm_6.s
 stream_connect=demux.out7:s2mm_7.s
 
+# Memory connections
+sp=switch_mm2s_pl.in:DDR[0]
+sp=s2mm_0.mem:DDR[1]
+sp=s2mm_1.mem:DDR[1]
+sp=s2mm_2.mem:DDR[1]
+sp=s2mm_3.mem:DDR[1]
+sp=s2mm_4.mem:DDR[1]
+sp=s2mm_5.mem:DDR[1]
+sp=s2mm_6.mem:DDR[1]
+sp=s2mm_7.mem:DDR[1]
+


### PR DESCRIPTION
## Summary
- Map each global-memory port in `linker_switch.cfg` to specific DDR banks

## Testing
- `v++ --version` *(fails: command not found)*
- `make link` *(fails: vitis_hls not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b08a29810c8320bf0110edef52fe8c