### PR TITLE
Ensure kernels use valid memory banks

### DIFF
--- a/common/linker_switch.cfg
+++ b/common/linker_switch.cfg
@@ -15,5 +15,13 @@ stream_connect=demux.out5:s2mm_5.s
 stream_connect=demux.out6:s2mm_6.s
 stream_connect=demux.out7:s2mm_7.s
 
-# NOTE: No 'sp=' lines on purpose. Let v++ auto-place to the valid LPDDR/DDR bank
-# exposed by your VEK280 platform. This avoids all the DDR[0]/DDR[1] name fights.
+# ---- Explicit memory mapping ----
+sp=switch_mm2s.in:LPDDR
+sp=s2mm_0.mem:LPDDR
+sp=s2mm_1.mem:LPDDR
+sp=s2mm_2.mem:LPDDR
+sp=s2mm_3.mem:LPDDR
+sp=s2mm_4.mem:LPDDR
+sp=s2mm_5.mem:LPDDR
+sp=s2mm_6.mem:LPDDR
+sp=s2mm_7.mem:LPDDR


### PR DESCRIPTION
## Summary
- Explicitly map switch_mm2s and s2mm instances to LPDDR in linker config
- Validate kernel memory group IDs against device bank count in host code

## Testing
- `make -C host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0af195c9c832088695e6e552ec5f4