### PR TITLE
Fix XRT device info query for bank count

### DIFF
--- a/host/host.cpp
+++ b/host/host.cpp
@@ -89,7 +89,11 @@ int main(int argc, char** argv){
     const int mm2s_gid = k_mm2s.group_id(0);
     const int s2mm_gid = k_s2mm.group_id(0);
 
-    const auto nbanks = dev.get_info<xrt::device::info::num_banks>();
+    // Query the number of memory banks on the device.
+    // The XRT API expects the query to use the `xrt::info::device`
+    // namespace, not `xrt::device::info` which was used previously and
+    // caused compilation to fail on recent XRT releases.
+    const auto nbanks = dev.get_info<xrt::info::device::memory_bank_count>();
     auto is_valid_bank = [nbanks](int gid) {
       return gid >= 0 && gid < static_cast<int>(nbanks) && gid != 0xFFFF;
     };


### PR DESCRIPTION
## Summary
- fix XRT API call to query the number of memory banks using the `memory_bank_count` enum in the `xrt::info::device` namespace

## Testing
- `make host` *(fails: aarch64-linux-gnu-g++: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b54177fc8320a3eb0e13f67ac561