### PR TITLE
Handle all packets for second receiver

### DIFF
--- a/sw/host.cpp
+++ b/sw/host.cpp
@@ -16,9 +16,10 @@ using namespace adf;
 using namespace std;
 
 int main(int argc, char* argv[]) {
-	int packet_num=2;
-	int total_packet_num=2*4;
-	int mem_size=packet_num*32;
+        int packet_num=2;
+        int total_packet_num=packet_num*4;
+        int total_packet_num2=packet_num*8;
+        int mem_size=packet_num*32;
 
 	if(argc != 2) {
 		std::cout << "Usage: " << argv[0] <<" <xclbin>" << std::endl;
@@ -140,7 +141,7 @@ int main(int argc, char* argv[]) {
 
 	xrtKernelHandle hls_packet_receiver_k2 = xrtPLKernelOpen(dhdl, uuid, "hls_packet_receiver2:{hls_packet_receiver_2}");
 	xrtRunHandle hls_packet_receiver_r2 = xrtRunOpen(hls_packet_receiver_k2);
-	xrtRunSetArg(hls_packet_receiver_r2, 5, total_packet_num);
+        xrtRunSetArg(hls_packet_receiver_r2, 5, total_packet_num2);
 	xrtRunStart(hls_packet_receiver_r2);
 	std::cout<<" output kernel2 complete"<<std::endl;
 


### PR DESCRIPTION
## Summary
- Ensure second packet receiver consumes all packets by computing `total_packet_num2` as `packet_num * 8`
- Pass the new total to `hls_packet_receiver2` in host application

## Testing
- `make -C sw` *(fails: No rule to make target '../Work/ps/c_rts/aie_control_xrt.cpp')*

------
https://chatgpt.com/codex/tasks/task_e_68b33788f7988320a533618056044001