### PR TITLE
Adjust packet sender argument index

### DIFF
--- a/sw/host.cpp
+++ b/sw/host.cpp
@@ -159,7 +159,7 @@ int main(int argc, char* argv[]) {
 	xrtRunStart(mm2s_r6);
         xrtKernelHandle hls_packet_sender_k = xrtPLKernelOpen(dhdl, uuid, "hls_packet_sender");
 	xrtRunHandle hls_packet_sender_r = xrtRunOpen(hls_packet_sender_k);
-	xrtRunSetArg(hls_packet_sender_r, 5, packet_num);
+        xrtRunSetArg(hls_packet_sender_r, 8, packet_num);
 	xrtRunStart(hls_packet_sender_r);
 	std::cout<<" input kernel complete"<<std::endl;
 


### PR DESCRIPTION
## Summary
- fix host app to pass `packet_num` as argument index 8 in `hls_packet_sender`

## Testing
- `make run` *(fails: /bin/sh: 1: v++: not found; cp: cannot stat '../Work/temp/packet_ids_c.h': No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b37e4be3b083209e8da77f88bb1324