### PR TITLE
Fix packet receiver argument index

### DIFF
--- a/sw/host.cpp
+++ b/sw/host.cpp
@@ -120,9 +120,9 @@ int main(int argc, char* argv[]) {
 	std::cout<<" output kernel complete"<<std::endl;
 
 	xrtKernelHandle hls_packet_receiver_k2 = xrtPLKernelOpen(dhdl, uuid, "hls_packet_receiver2:{hls_packet_receiver_2}");
-	xrtRunHandle hls_packet_receiver_r2 = xrtRunOpen(hls_packet_receiver_k2);
-        xrtRunSetArg(hls_packet_receiver_r2, 5, total_packet_num2); // six packets per iteration
-	xrtRunStart(hls_packet_receiver_r2);
+        xrtRunHandle hls_packet_receiver_r2 = xrtRunOpen(hls_packet_receiver_k2);
+        xrtRunSetArg(hls_packet_receiver_r2, 3, total_packet_num2); // six packets per iteration
+        xrtRunStart(hls_packet_receiver_r2);
 	std::cout<<" output kernel2 complete"<<std::endl;
 
 	// start input kernels


### PR DESCRIPTION
## Summary
- fix argument index for second packet receiver to enable proper packet count

## Testing
- `make run` *(fails: cp: cannot stat '../Work/temp/packet_ids_c.h')*
- `make aie` *(fails: v++: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b37ef46e1c83208c0c65fa47f25348