### PR TITLE
Add progress script usage and project status image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project demonstrates a custom low-latency neural network pipeline implemented on the AMD Versal™ VEK280 platform using the AI Engine-ML (AIE-ML) and Vitis tools. The core model consists of two dense layers with leaky ReLU activations after each layer, targeting power-efficient acceleration of small MLP inference tasks. It supports runtime configurability of dimensions and data types (`int8`, `int16`, `float16`, `float32`), with automated test data generation and full simulation support.
 
+![Project Status](tools/project_status_progress_bar.png)
+
 The design partitions work across three components of the Versal architecture:
 
 - **AI Engine‑ML graphs** – execute dense layers. The project now contains three

--- a/progress.yaml
+++ b/progress.yaml
@@ -14,6 +14,6 @@ items:
   - { label: "Component simulations", percent: 100, note: "HLS C-sim/aiesim/hw_emu validated per-block" }
   - { label: "Full-system bring-up (VEK280)", percent: 0.60, note: "Full system link, package" }
   - { label: "Validation & benchmarking", percent: 0.30, note: "Latency/II/power/accuracy sweeps pending" }
-  - { label: "Explore other acritectures", percent: null, note: "Reduced precision, data shuffling, GMEM" }
+  - { label: "Precision Tuning", percent: null, note: "Reduced precision, data shuffling, GMEM" }
   - { label: "Reduced precision (fp32→fp16/fixed)", percent: null, note: "TBD" }
   - { label: "Dosumentation for community", percent: null, note: "TBD" }

--- a/tools/poster_progress.py
+++ b/tools/poster_progress.py
@@ -6,6 +6,9 @@ Poster Progress Bar (PNG + SVG)
 - Placeholders: use percent = null / NA / - to render hatched bars with "—"
 - Palette defaults match your poster (AIE/PL/PS scheme-friendly)
 
+Basic usage:
+  python tools/poster_progress.py --config progress.yaml
+
 Usage examples:
   python tools/poster_progress.py --config progress.yaml --out-prefix assets/status
   python tools/poster_progress.py --title "Project Status — {date}" \


### PR DESCRIPTION
## Summary
- rename progress utility to `poster_progress.py` and document basic usage
- move and refresh `progress.yaml`
- show generated project status image in main README

## Testing
- `python tools/poster_progress.py --config progress.yaml` *(fails: No module named 'PIL')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8aa354f2c8320b8b4486ef7597a95