### PR TITLE
Use v++ for aieml graph build

### DIFF
--- a/aieml/Makefile
+++ b/aieml/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
 # Target platform for hardware compilation.
 PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm
 
-# Target for compilation and simulation. Options: x86sim, hw
+# Target for compilation. Options: hw, hw_emu
 TARGET       ?= hw
 
 # Location of input/weight files used by PLIO connections (override from top-level)
@@ -17,11 +17,8 @@ TARGET       ?= hw
 DATA_DIR    ?= ../../data
 DATA_DIR := $(abspath $(DATA_DIR))
 
-# Frequency for the Programmable Logic (PL) interfaces in MHz.
-PL_FREQ_MHZ  ?= 300
-
 # Path to your Vitis installation.
-VITIS_PATH   ?= /tools/Xilinx/Vitis/2024.1
+VITIS_PATH   ?= /tools/Xilinx/Vitis/2024.2
 
 # ##########################################################################
 # ##########################################################################
@@ -38,12 +35,12 @@ DSPLIB_PATH  ?= /home/synthara/VersalPrjs/Vitis_Libraries/dsp
 GRAPH_SRC     := graph.cpp
 WORK_DIR      := Work
 GRAPH_LIB     := $(WORK_DIR)/libadf.a
+AIE_CFG       := aie.cfg
 
 
 # ==== TOOLS ====
-AIECC        := aiecompiler
+VPP          := v++
 AIESIM       := aiesimulator
-X86SIM       := x86simulator
 
 
 # ==== COMPILER FLAGS ====
@@ -55,12 +52,14 @@ AIE_INCLUDE_FLAGS := \
         --include="$(DSPLIB_PATH)/L1/include/aie" \
         --include="$(DSPLIB_PATH)/L2/include/aie"
 
-# Full AIE compiler command flags, assembled from variables above.
-AIE_FLAGS := \
-        --v \
-        --platform=$(PLATFORM) \
+# Full v++ command flags, assembled from variables above.
+VPP_FLAGS := \
+        -c \
+        --mode aie \
         --target=$(TARGET) \
-        --pl-freq=$(PL_FREQ_MHZ) \
+        --platform=$(PLATFORM) \
+        --work_dir=$(WORK_DIR) \
+        --config=$(AIE_CFG) \
         $(AIE_INCLUDE_FLAGS)
 
 
@@ -74,7 +73,7 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
+$(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h $(AIE_CFG)
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"
@@ -86,26 +85,20 @@ $(GRAPH_LIB): $(GRAPH_SRC) graph.h ../common/nn_defs.h ../common/data_paths.h
 		exit 1; \
 	fi
 	@set -o pipefail; \
-	$(AIECC) $(AIE_FLAGS) $(GRAPH_SRC) --workdir=$(WORK_DIR) 2>&1 | tee $(WORK_DIR)/aiecompiler.log
+	$(VPP) $(VPP_FLAGS) $(GRAPH_SRC) 2>&1 | tee $(WORK_DIR)/vpp_aie.log
 	@echo "COMPLETE: AIE graph compiled."
 
 # --- Simulation ---
 sim: graph
-ifeq ($(TARGET),x86sim)
-	@echo "--- Starting x86 Simulation ---"
-	$(X86SIM) --pkg-dir=$(WORK_DIR)
-	@echo "COMPLETE: x86sim simulation finished."
-else
-	@echo "--- Starting Hardware Simulation (aiesimulator) ---"
+	@echo "--- Starting AI Engine simulation (aiesimulator) ---"
 	DATA_DIR=$(DATA_DIR) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
-	@echo "COMPLETE: Hardware simulation finished."
-endif
+	@echo "COMPLETE: AI Engine simulation finished."
 
 # --- Clean Target ---
 clean:
 	@echo "--- Cleaning Workspace ---"
 	rm -rf $(WORK_DIR) .Xil *.log *.csv *.db *.aiecompile_summary \
-	       aiesimulator_output build_hw build_x86sim x86simulator_output \
+	       aiesimulator_output build_hw \
 	       pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
 	       *.json *.vcd
 	@echo "CLEANED: Build and work directories removed."

--- a/aieml/README.md
+++ b/aieml/README.md
@@ -19,20 +19,28 @@ programmable logic. Later stages are implemented in
 
 ## Build
 
-The supplied `Makefile` wraps the standard build flow. From the repository
-root, compile the graph with:
+The supplied `Makefile` wraps the standard build flow (now using `v++` so the
+`aie.cfg` partition directives take effect). From the repository root, compile
+the graph with:
 
 ```bash
 cd aieml
-make graph TARGET=hw       # or TARGET=x86sim
+make graph TARGET=hw       # or TARGET=hw_emu
 ```
 
 To invoke the compiler directly without the wrapper:
 
 ```bash
 cd aieml
-v++ --compile --mode aie --target hw ./graph.cpp \
-    --platform=${PLATFORM} -I./data
+v++ -c --mode aie --target hw graph.cpp \
+    --platform=${PLATFORM} \
+    --work_dir=Work \
+    --config=aie.cfg \
+    --include="./" \
+    --include="../common" \
+    --include="${DSPLIB_PATH}/L1/src/aie" \
+    --include="${DSPLIB_PATH}/L1/include/aie" \
+    --include="${DSPLIB_PATH}/L2/include/aie"
 ```
 
 Both commands produce `Work/libadf.a` inside this directory.
@@ -42,7 +50,7 @@ Both commands produce `Work/libadf.a` inside this directory.
 After a successful build, run cycle-approximate simulation:
 
 ```bash
-make sim TARGET=hw        # uses `aiesimulator` under the hood
+make sim                  # uses `aiesimulator` under the hood
 # or run manually
 # aiesimulator --pkg-dir=Work --profile --dump-vcd=foo
 ```


### PR DESCRIPTION
## Summary
- replace the aieml graph build flow to call `v++ -c --mode aie` so the new `aie.cfg` partition file is honored
- tidy the Makefile to reflect the new toolchain, add the config as a dependency, fix the recipe indentation so GNU Make accepts it, and simplify the simulation rule
- update the aieml README with the revised build and manual command examples

## Testing
- not run (Vitis toolchain is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68c97a31af48832091af88267e18295c