### PR TITLE
Preserve packet headers in AIE cores

### DIFF
--- a/aie/aie_core1.cpp
+++ b/aie/aie_core1.cpp
@@ -4,17 +4,13 @@ SPDX-License-Identifier: MIT
 */
 #include <aie_api/aie.hpp>
 #include <aie_api/aie_adf.hpp>
-const uint32 pktType=0;
-
 void aie_core1(input_pktstream *in,output_pktstream *out){
-	readincr(in);//read header and discard
-	uint32 ID=getPacketid(out,0);//for output pktstream
-	writeHeader(out,pktType,ID); //Generate header for output
+        uint32 header = readincr(in);
+        writeincr(out, header, false);
 
-	bool tlast;
-	for(int i=0;i<8;i++){
-		int32 tmp=readincr(in,tlast);
-		tmp+=1;
-		writeincr(out,tmp,i==7);//TLAST=1 for last word
-	}
+        bool tlast;
+        for(int i=0;i<8;i++){
+                int32 tmp=readincr(in,tlast);
+                writeincr(out,tmp,tlast);//Preserve TLAST from input
+        }
 }

--- a/aie/aie_core2.cpp
+++ b/aie/aie_core2.cpp
@@ -4,17 +4,13 @@ SPDX-License-Identifier: MIT
 */
 #include <aie_api/aie.hpp>
 #include <aie_api/aie_adf.hpp>
-const uint32 pktType=0;
-
 void aie_core2(input_pktstream *in,output_pktstream *out){
-	readincr(in);//read header and discard
-	uint32 ID=getPacketid(out,0);//for output pktstream
-	writeHeader(out,pktType,ID); //Generate header for output
+        uint32 header = readincr(in);
+        writeincr(out, header, false);
 
-	bool tlast;
-	for(int i=0;i<8;i++){
-		int32 tmp=readincr(in,tlast);
-		tmp+=2;
-		writeincr(out,tmp,i==7);//TLAST=1 for last word
-	}
+        bool tlast;
+        for(int i=0;i<8;i++){
+                int32 tmp=readincr(in,tlast);
+                writeincr(out,tmp,tlast);//Preserve TLAST from input
+        }
 }

--- a/aie/aie_core3.cpp
+++ b/aie/aie_core3.cpp
@@ -4,17 +4,13 @@ SPDX-License-Identifier: MIT
 */
 #include <aie_api/aie.hpp>
 #include <aie_api/aie_adf.hpp>
-const uint32 pktType=0;
-
 void aie_core3(input_pktstream *in,output_pktstream *out){
-	readincr(in);//read header and discard
-	uint32 ID=getPacketid(out,0);//for output pktstream
-	writeHeader(out,pktType,ID); //Generate header for output
+        uint32 header = readincr(in);
+        writeincr(out, header, false);
 
-	bool tlast;
-	for(int i=0;i<8;i++){
-		int32 tmp=readincr(in,tlast);
-		tmp+=3;
-		writeincr(out,tmp,i==7);//TLAST=1 for last word
-	}
+        bool tlast;
+        for(int i=0;i<8;i++){
+                int32 tmp=readincr(in,tlast);
+                writeincr(out,tmp,tlast);//Preserve TLAST from input
+        }
 }

--- a/aie/aie_core4.cpp
+++ b/aie/aie_core4.cpp
@@ -4,17 +4,13 @@ SPDX-License-Identifier: MIT
 */
 #include <aie_api/aie.hpp>
 #include <aie_api/aie_adf.hpp>
-const uint32 pktType=0;
-
 void aie_core4(input_pktstream *in,output_pktstream *out){
-	readincr(in);//read header and discard
-	uint32 ID=getPacketid(out,0);//for output pktstream
-	writeHeader(out,pktType,ID); //Generate header for output
+        uint32 header = readincr(in);
+        writeincr(out, header, false);
 
-	bool tlast;
-	for(int i=0;i<8;i++){
-		int32 tmp=readincr(in,tlast);
-		tmp+=4;
-		writeincr(out,tmp,i==7);//TLAST=1 for last word
-	}
+        bool tlast;
+        for(int i=0;i<8;i++){
+                int32 tmp=readincr(in,tlast);
+                writeincr(out,tmp,tlast);//Preserve TLAST from input
+        }
 }


### PR DESCRIPTION
## Summary
- forward the incoming packet header word through each AI Engine kernel
- drop the payload offset adds so the payload words are passed through unchanged

## Testing
- make aie *(fails: v++ not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e4b217e883209ac52d25a4959abe