### PR TITLE
Simplify host build to remove dependency on generated ADF control code

### DIFF
--- a/sw/Makefile
+++ b/sw/Makefile
@@ -3,8 +3,6 @@ SYSROOT ?= /opt/petalinux/2024.2/sysroots/cortexa72-cortexa53-xilinx-linux
 CXX     := aarch64-linux-gnu-g++
 # Default data directory lives one level above the project root
 HOST_EXE     = ../host.exe
-HOST_OBJ   = aie_control_xrt.o host.o
-AIE_CTRL_CPP = ../Work/ps/c_rts/aie_control_xrt.cpp
 # Sources and targets
 SRC := host.cpp
 OBJ := $(SRC:.cpp=.o)
@@ -19,23 +17,20 @@ CXXFLAGS ?= -Wall -c -std=c++17 -Wno-int-to-pointer-cast \
         -I./ -I./src/ -I../aie -I$(XILINX_VITIS)/aietools/include 
 
 LDFLAGS ?= --sysroot=$(SYSROOT) \
-	-L$(SYSROOT)/usr/lib \
-	-lstdc++ -lxrt_coreutil -lxrt_core -lpthread -ladf_api_xrt -lgcc -lc -lxilinxopencl -lrt -ldl -lcrypt -L$(XILINX_VITIS)/aietools/lib/aarch64.o
+        -L$(SYSROOT)/usr/lib \
+        -lstdc++ -lxrt_coreutil -lxrt_core -lpthread -lgcc -lc -lxilinxopencl -lrt -ldl -lcrypt
 
 .PHONY: all clean
 
 # all: $(OUT)
 
-${HOST_EXE}: ${HOST_OBJ}
+${HOST_EXE}: ${OBJ}
 	${CXX} -o $@ $^ ${LDFLAGS}
 
 %.o: %.cpp
 	${CXX} ${CXXFLAGS} -o $@ $<
 
 
-aie_control_xrt.cpp: ${AIE_CTRL_CPP}
-	cp -f ${AIE_CTRL_CPP} .
-
 clean:
-	rm -f $(OBJ) $(OUT) *.log ${HOST_OBJ} .Xil ${HOST_EXE} aie_control_xrt.cpp
+	rm -f $(OBJ) $(OUT) *.log .Xil ${HOST_EXE} aie_control_xrt.cpp
 	@echo "🧹 Cleaned up build artifacts"

--- a/sw/host.cpp
+++ b/sw/host.cpp
@@ -7,12 +7,9 @@ SPDX-License-Identifier: MIT
 #include <iostream>
 #include <unistd.h>
 #include <complex>
-#include "adf/adf_api/XRTConfig.h"
+#include "experimental/xrt_graph.h"
 #include "experimental/xrt_kernel.h"
 
-#include "graph.cpp"
-
-using namespace adf;
 using namespace std;
 
 int main(int argc, char* argv[]) {
@@ -163,9 +160,13 @@ int main(int argc, char* argv[]) {
 	xrtRunStart(hls_packet_sender_r);
 	std::cout<<" input kernel complete"<<std::endl;
 
-	// start graph
-        adf::registerXRT(dhdl, uuid);
-        gr.run(2);
+        // start graph
+        auto graph = xrtGraphOpen(dhdl, uuid, "mygraph");
+        if(!graph){
+                std::cerr << "Failed to open graph mygraph" << std::endl;
+                return EXIT_FAILURE;
+        }
+        xrtGraphRun(graph, 2);
         std::cout<<" graph run complete"<<std::endl;
 
         // wait for all runs to complete
@@ -278,7 +279,9 @@ int main(int argc, char* argv[]) {
         xrtBOFree(in_bo4);
         xrtBOFree(in_bo5);
         xrtBOFree(in_bo6);
-        gr.end();
+        xrtGraphWait(graph, 0);
+        xrtGraphEnd(graph);
+        xrtGraphClose(graph);
         xrtDeviceClose(dhdl);
 	
 	std::cout << "TEST " << (match ? "FAILED" : "PASSED") << std::endl; 


### PR DESCRIPTION
## Summary
- stop building the generated `aie_control_xrt.cpp` helper and link the host app only against its own sources
- update the host application to use the native XRT graph API instead of `adf::registerXRT`
- trim linker flags that required the missing ADF control headers and libraries

## Testing
- `make -C sw` *(fails: `aarch64-linux-gnu-g++` toolchain is not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ec981f4c8320ad9f240704118595