### PR TITLE
Handle TLAST-terminated packets in AI Engine cores

### DIFF
--- a/aie/aie_core1.cpp
+++ b/aie/aie_core1.cpp
@@ -9,8 +9,8 @@ void aie_core1(input_pktstream *in,output_pktstream *out){
         writeincr(out, header, false);
 
         bool tlast;
-        for(int i=0;i<8;i++){
+        do {
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        } while(!tlast);
 }

--- a/aie/aie_core2.cpp
+++ b/aie/aie_core2.cpp
@@ -9,8 +9,8 @@ void aie_core2(input_pktstream *in,output_pktstream *out){
         writeincr(out, header, false);
 
         bool tlast;
-        for(int i=0;i<8;i++){
+        do {
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        } while(!tlast);
 }

--- a/aie/aie_core3.cpp
+++ b/aie/aie_core3.cpp
@@ -9,8 +9,8 @@ void aie_core3(input_pktstream *in,output_pktstream *out){
         writeincr(out, header, false);
 
         bool tlast;
-        for(int i=0;i<8;i++){
+        do {
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        } while(!tlast);
 }

--- a/aie/aie_core4.cpp
+++ b/aie/aie_core4.cpp
@@ -9,8 +9,8 @@ void aie_core4(input_pktstream *in,output_pktstream *out){
         writeincr(out, header, false);
 
         bool tlast;
-        for(int i=0;i<8;i++){
+        do {
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        } while(!tlast);
 }


### PR DESCRIPTION
## Summary
- stream AI Engine core packet payloads until TLAST so variable-length packets are forwarded intact

## Testing
- make run *(fails: `v++` tool is unavailable in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb418d83e48320b3bb1555fc0aefc1