### PR TITLE
Handle variable-length packets in AIE cores

### DIFF
--- a/aie/aie_core1.cpp
+++ b/aie/aie_core1.cpp
@@ -8,9 +8,9 @@ void aie_core1(input_pktstream *in,output_pktstream *out){
         uint32 header = readincr(in);
         writeincr(out, header, false);
 
-        bool tlast;
-        for(int i=0;i<8;i++){
+        bool tlast = false;
+        do{
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        }while(!tlast);
 }

--- a/aie/aie_core2.cpp
+++ b/aie/aie_core2.cpp
@@ -8,9 +8,9 @@ void aie_core2(input_pktstream *in,output_pktstream *out){
         uint32 header = readincr(in);
         writeincr(out, header, false);
 
-        bool tlast;
-        for(int i=0;i<8;i++){
+        bool tlast = false;
+        do{
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        }while(!tlast);
 }

--- a/aie/aie_core3.cpp
+++ b/aie/aie_core3.cpp
@@ -8,9 +8,9 @@ void aie_core3(input_pktstream *in,output_pktstream *out){
         uint32 header = readincr(in);
         writeincr(out, header, false);
 
-        bool tlast;
-        for(int i=0;i<8;i++){
+        bool tlast = false;
+        do{
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        }while(!tlast);
 }

--- a/aie/aie_core4.cpp
+++ b/aie/aie_core4.cpp
@@ -8,9 +8,9 @@ void aie_core4(input_pktstream *in,output_pktstream *out){
         uint32 header = readincr(in);
         writeincr(out, header, false);
 
-        bool tlast;
-        for(int i=0;i<8;i++){
+        bool tlast = false;
+        do{
                 int32 tmp=readincr(in,tlast);
                 writeincr(out,tmp,tlast);//Preserve TLAST from input
-        }
+        }while(!tlast);
 }


### PR DESCRIPTION
## Summary
- replace the fixed-length inner loops in each AI Engine kernel with a TLAST-driven `do { } while()` so longer packets are drained

## Testing
- `make aie` *(fails: `v++` not available in container)*
- `make host` *(fails: `aarch64-linux-gnu-g++` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc616d92748320bbdbecb95c2dec0b