### PR TITLE
Clamp packet payload counts and enforce receiver loops

### DIFF
--- a/pl/hls_packet_receiver.cpp
+++ b/pl/hls_packet_receiver.cpp
@@ -11,27 +11,27 @@ static const int PACKET_NUM=4;
 
 static const unsigned int packet_ids[PACKET_NUM]={Dataout0_0, Dataout0_1, Dataout0_2, Dataout0_3};
 
+typedef ap_axiu<32,0,0,0> axis32_t;
+
 unsigned int getPacketId(ap_uint<32> header){
 #pragma HLS inline
-	ap_uint<32> ID=0;
-	ID(7,0)=header(7,0);
-	return ID;
+        ap_uint<32> ID=0;
+        ID(7,0)=header(7,0);
+        return ID;
 }
 
-void hls_packet_receiver(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu<32,0,0,0>> &out0,hls::stream<ap_axiu<32,0,0,0>> &out1,hls::stream<ap_axiu<32,0,0,0>> &out2,hls::stream<ap_axiu<32,0,0,0>> &out3,
-	const unsigned int total_num_packet){
-        for(unsigned int iter=0;iter<total_num_packet;iter++){
-                ap_axiu<32,0,0,0> header=in.read();//first word is packet header
+void hls_packet_receiver(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,hls::stream<axis32_t> &out2,hls::stream<axis32_t> &out3,
+        const unsigned int total_num_packet){
+        const int packet_limit = static_cast<int>(total_num_packet);
+        for(int pkt=0; pkt<packet_limit; ++pkt){
+                axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
-                unsigned int channel=0;
                 bool valid_channel = (ID < PACKET_NUM);
-                if(valid_channel){
-                        channel=packet_ids[ID];
-                }
+                unsigned int channel = valid_channel ? packet_ids[ID] : 0;
 
                 bool last_word=false;
                 do{
-                        ap_axiu<32,0,0,0> tmp=in.read();
+                        axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
                                 switch(channel){
@@ -39,6 +39,7 @@ void hls_packet_receiver(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu
                                 case 1:out1.write(tmp);break;
                                 case 2:out2.write(tmp);break;
                                 case 3:out3.write(tmp);break;
+                                default:break;
                                 }
                         }
                 }while(!last_word);

--- a/pl/hls_packet_receiver2.cpp
+++ b/pl/hls_packet_receiver2.cpp
@@ -11,17 +11,20 @@ static const int PACKET_NUM=2;
 
 static const unsigned int packet_ids[PACKET_NUM]={4,5};
 
+typedef ap_axiu<32,0,0,0> axis32_t;
+
 unsigned int getPacketId(ap_uint<32> header){
 #pragma HLS inline
-	ap_uint<32> ID=0;
-	ID(7,0)=header(7,0);
-	return ID;
+        ap_uint<32> ID=0;
+        ID(7,0)=header(7,0);
+        return ID;
 }
 
-void hls_packet_receiver2(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu<32,0,0,0>> &out0,hls::stream<ap_axiu<32,0,0,0>> &out1,
-	const unsigned int total_num_packet){
-        for(unsigned int iter=0;iter<total_num_packet;iter++){
-                ap_axiu<32,0,0,0> header=in.read();//first word is packet header
+void hls_packet_receiver2(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,
+        const unsigned int total_num_packet){
+        const int packet_limit = static_cast<int>(total_num_packet);
+        for(int pkt=0; pkt<packet_limit; ++pkt){
+                axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
                 unsigned int channel=0;
                 bool valid_channel=false;
@@ -36,12 +39,13 @@ void hls_packet_receiver2(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axi
 
                 bool last_word=false;
                 do{
-                        ap_axiu<32,0,0,0> tmp=in.read();
+                        axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
                                 switch(channel){
                                 case 0:out0.write(tmp);break;
                                 case 1:out1.write(tmp);break;
+                                default:break;
                                 }
                         }
                 }while(!last_word);


### PR DESCRIPTION
## Summary
- Clamp the host-side payload word count to at least one word, reuse it for every mm2s/s2mm transfer, and assert the configured packet counts
- Update the packet sender to emit exactly one header and N payload words per channel with TLAST only on the final sample
- Make both packet receivers iterate for the expected packet counts, draining each payload stream until TLAST before moving on

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc8ffe8f4c8320b7631f6680c95ac5