### PR TITLE
Fix HLS stream selection in packet sender

### DIFF
--- a/pl/hls_packet_receiver.cpp
+++ b/pl/hls_packet_receiver.cpp
@@ -11,27 +11,27 @@ static const int PACKET_NUM=4;
 
 static const unsigned int packet_ids[PACKET_NUM]={Dataout0_0, Dataout0_1, Dataout0_2, Dataout0_3};
 
+typedef ap_axiu<32,0,0,0> axis32_t;
+
 unsigned int getPacketId(ap_uint<32> header){
 #pragma HLS inline
-	ap_uint<32> ID=0;
-	ID(7,0)=header(7,0);
-	return ID;
+        ap_uint<32> ID=0;
+        ID(7,0)=header(7,0);
+        return ID;
 }
 
-void hls_packet_receiver(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu<32,0,0,0>> &out0,hls::stream<ap_axiu<32,0,0,0>> &out1,hls::stream<ap_axiu<32,0,0,0>> &out2,hls::stream<ap_axiu<32,0,0,0>> &out3,
-	const unsigned int total_num_packet){
-        for(unsigned int iter=0;iter<total_num_packet;iter++){
-                ap_axiu<32,0,0,0> header=in.read();//first word is packet header
+void hls_packet_receiver(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,hls::stream<axis32_t> &out2,hls::stream<axis32_t> &out3,
+        const unsigned int total_num_packet){
+        const int packet_limit = static_cast<int>(total_num_packet);
+        for(int pkt=0; pkt<packet_limit; ++pkt){
+                axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
-                unsigned int channel=0;
                 bool valid_channel = (ID < PACKET_NUM);
-                if(valid_channel){
-                        channel=packet_ids[ID];
-                }
+                unsigned int channel = valid_channel ? packet_ids[ID] : 0;
 
                 bool last_word=false;
                 do{
-                        ap_axiu<32,0,0,0> tmp=in.read();
+                        axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
                                 switch(channel){
@@ -39,6 +39,7 @@ void hls_packet_receiver(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu
                                 case 1:out1.write(tmp);break;
                                 case 2:out2.write(tmp);break;
                                 case 3:out3.write(tmp);break;
+                                default:break;
                                 }
                         }
                 }while(!last_word);

--- a/pl/hls_packet_receiver2.cpp
+++ b/pl/hls_packet_receiver2.cpp
@@ -11,17 +11,20 @@ static const int PACKET_NUM=2;
 
 static const unsigned int packet_ids[PACKET_NUM]={4,5};
 
+typedef ap_axiu<32,0,0,0> axis32_t;
+
 unsigned int getPacketId(ap_uint<32> header){
 #pragma HLS inline
-	ap_uint<32> ID=0;
-	ID(7,0)=header(7,0);
-	return ID;
+        ap_uint<32> ID=0;
+        ID(7,0)=header(7,0);
+        return ID;
 }
 
-void hls_packet_receiver2(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axiu<32,0,0,0>> &out0,hls::stream<ap_axiu<32,0,0,0>> &out1,
-	const unsigned int total_num_packet){
-        for(unsigned int iter=0;iter<total_num_packet;iter++){
-                ap_axiu<32,0,0,0> header=in.read();//first word is packet header
+void hls_packet_receiver2(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,
+        const unsigned int total_num_packet){
+        const int packet_limit = static_cast<int>(total_num_packet);
+        for(int pkt=0; pkt<packet_limit; ++pkt){
+                axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
                 unsigned int channel=0;
                 bool valid_channel=false;
@@ -36,12 +39,13 @@ void hls_packet_receiver2(hls::stream<ap_axiu<32,0,0,0>> &in, hls::stream<ap_axi
 
                 bool last_word=false;
                 do{
-                        ap_axiu<32,0,0,0> tmp=in.read();
+                        axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
                                 switch(channel){
                                 case 0:out0.write(tmp);break;
                                 case 1:out1.write(tmp);break;
+                                default:break;
                                 }
                         }
                 }while(!last_word);

--- a/pl/hls_packet_sender.cpp
+++ b/pl/hls_packet_sender.cpp
@@ -92,7 +92,9 @@ extern "C" void hls_packet_sender(
     channel_loop:
     for (int i = 0; i < PACKET_NUM; ++i) {
         unsigned int N = words[i];
-        if (N == 0) continue; // nothing to send on this channel
+        if (N == 0) {
+            continue; // safety guard; host side guarantees N >= 1
+        }
 
         const unsigned int ID = packet_ids[i];
         const ap_uint<32>  hdr_word = generateHeader(pktType, ID);
@@ -102,13 +104,11 @@ extern "C" void hls_packet_sender(
         hdr.keep = -1;
         hdr.last = 0;
 
-        // Route: ch 0..3 → AIE only; ch 4..5 → PL only
-        const bool to_aie = (i < 4);
-        const bool to_pl  = (i >= 4);
-
-        // ---- Emit header on the correct destination only ----
-        if (to_aie) { out.write(hdr); }
-        if (to_pl ) { plout.write(hdr); }
+        if (i < 4) {
+            out.write(hdr);
+        } else {
+            plout.write(hdr);
+        }
 
         payload_loop:
         for (unsigned int j = 0; j < N; ++j) {
@@ -118,8 +118,11 @@ extern "C" void hls_packet_sender(
             d.keep = -1;
             d.last = (j == (N - 1)) ? (ap_uint<1>)1 : (ap_uint<1>)0;
 
-            if (to_aie) { out.write(d); }
-            if (to_pl ) { plout.write(d); }
+            if (i < 4) {
+                out.write(d);
+            } else {
+                plout.write(d);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- update the packet sender to write headers and payloads directly to the appropriate AI Engine or PL output stream so HLS can implement the interfaces

## Testing
- `make -C pl hls_packet_sender.xo` *(fails: missing ../Work/temp/packet_ids_c.h)*

------
https://chatgpt.com/codex/tasks/task_e_68cc8ffe8f4c8320b7631f6680c95ac5