### PR TITLE
Fix stream routing in packet sender

### DIFF
--- a/pl/hls_packet_sender.cpp
+++ b/pl/hls_packet_sender.cpp
@@ -104,8 +104,11 @@ extern "C" void hls_packet_sender(
         hdr.keep = -1;
         hdr.last = 0;
 
-        hls::stream<axis32_t>* dest = (i < 4) ? &out : &plout;
-        dest->write(hdr);
+        if (i < 4) {
+            out.write(hdr);
+        } else {
+            plout.write(hdr);
+        }
 
         payload_loop:
         for (unsigned int j = 0; j < N; ++j) {
@@ -115,7 +118,11 @@ extern "C" void hls_packet_sender(
             d.keep = -1;
             d.last = (j == (N - 1)) ? (ap_uint<1>)1 : (ap_uint<1>)0;
 
-            dest->write(d);
+            if (i < 4) {
+                out.write(d);
+            } else {
+                plout.write(d);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- write packet headers and payloads directly to the AI Engine or PL AXIS ports
- preserve the existing header-plus-payload sequencing and TLAST handling for each channel

## Testing
- make hls_packet_sender.xo *(fails: missing ../Work/temp/packet_ids_c.h in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc95789dd083209dcac94d4c8893eb