### PR TITLE
Use literal packet IDs and validate routing

### DIFF
--- a/pl/hls_packet_receiver.cpp
+++ b/pl/hls_packet_receiver.cpp
@@ -5,11 +5,7 @@ SPDX-License-Identifier: MIT
 #include "hls_stream.h"
 #include "ap_int.h"
 #include "ap_axi_sdata.h"
-#include "packet_ids_c.h"
-
 static const int PACKET_NUM=4;
-
-static const unsigned int packet_ids[PACKET_NUM]={Dataout0_0, Dataout0_1, Dataout0_2, Dataout0_3};
 
 typedef ap_axiu<32,0,0,0> axis32_t;
 
@@ -27,14 +23,13 @@ void hls_packet_receiver(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,
                 axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
                 bool valid_channel = (ID < PACKET_NUM);
-                unsigned int channel = valid_channel ? packet_ids[ID] : 0;
 
                 bool last_word=false;
                 do{
                         axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
-                                switch(channel){
+                                switch(ID){
                                 case 0:out0.write(tmp);break;
                                 case 1:out1.write(tmp);break;
                                 case 2:out2.write(tmp);break;

--- a/pl/hls_packet_receiver2.cpp
+++ b/pl/hls_packet_receiver2.cpp
@@ -5,12 +5,6 @@ SPDX-License-Identifier: MIT
 #include "hls_stream.h"
 #include "ap_int.h"
 #include "ap_axi_sdata.h"
-#include "packet_ids_c.h"
-
-static const int PACKET_NUM=2;
-
-static const unsigned int packet_ids[PACKET_NUM]={4,5};
-
 typedef ap_axiu<32,0,0,0> axis32_t;
 
 unsigned int getPacketId(ap_uint<32> header){
@@ -26,22 +20,14 @@ void hls_packet_receiver2(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0
         for(int pkt=0; pkt<packet_limit; ++pkt){
                 axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
-                unsigned int channel=0;
-                bool valid_channel=false;
-
-                for(int idx=0; idx<PACKET_NUM; ++idx){
-                        if(ID==packet_ids[idx]){
-                                channel=idx;
-                                valid_channel=true;
-                                break;
-                        }
-                }
+                bool valid_channel = (ID == 4u) || (ID == 5u);
 
                 bool last_word=false;
                 do{
                         axis32_t tmp=in.read();
                         last_word = tmp.last;
                         if(valid_channel){
+                                unsigned int channel = ID - 4u;
                                 switch(channel){
                                 case 0:out0.write(tmp);break;
                                 case 1:out1.write(tmp);break;

--- a/pl/hls_packet_sender.cpp
+++ b/pl/hls_packet_sender.cpp
@@ -1,13 +1,10 @@
 #include "hls_stream.h"
 #include "ap_int.h"
 #include "ap_axi_sdata.h"
-#include "packet_ids_c.h"
-
 static const unsigned int pktType = 0;
 static const int PACKET_NUM = 6;
 
-// Macro values are generated in packet_ids_c.h
-static const unsigned int packet_ids[PACKET_NUM] = {Datain0_0, Datain0_1, Datain0_2, Datain0_3, 4, 5};
+static const unsigned int packet_ids[PACKET_NUM] = {0, 1, 2, 3, 4, 5};
 
 typedef ap_axiu<32, 0, 0, 0> axis32_t;
 
@@ -97,6 +94,8 @@ extern "C" void hls_packet_sender(
         }
 
         const unsigned int ID = packet_ids[i];
+        const bool to_aie = (ID < 4);
+        const bool to_pl  = (ID >= 4);
         const ap_uint<32>  hdr_word = generateHeader(pktType, ID);
 
         axis32_t hdr;
@@ -104,9 +103,9 @@ extern "C" void hls_packet_sender(
         hdr.keep = -1;
         hdr.last = 0;
 
-        if (i < 4) {
+        if (to_aie) {
             out.write(hdr);
-        } else {
+        } else if (to_pl) {
             plout.write(hdr);
         }
 
@@ -118,9 +117,9 @@ extern "C" void hls_packet_sender(
             d.keep = -1;
             d.last = (j == (N - 1)) ? (ap_uint<1>)1 : (ap_uint<1>)0;
 
-            if (i < 4) {
+            if (to_aie) {
                 out.write(d);
-            } else {
+            } else if (to_pl) {
                 plout.write(d);
             }
         }


### PR DESCRIPTION
## Summary
- use literal IDs for all packet channels in the HLS sender and route traffic by numeric ID while keeping the header ID in bits [7:0]
- update the AI Engine receiver to decode IDs from the header low byte, validate the range, and drain invalid packets without routing them
- update the PL receiver to accept only IDs 4 and 5, derive the 0/1 channel index from the ID, and drop any invalid packets while draining their payloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6803592883209a4452fc39a04a43