### PR TITLE
Packetization cleanup

### DIFF
--- a/docs/packet_contract.md
+++ b/docs/packet_contract.md
@@ -1,0 +1,13 @@
+# Packet Contract v1
+
+- Stream width: 32-bit AXI4-Stream.
+- Packet format: `[HEADER][N payload words]`, TLAST asserted on the last payload word.
+- Header v1 fields:
+  - `[7:0]` — `ID` (0..3 → AIE domain; 4..5 → PL domain)
+  - `[11:8]` — `RESERVED = 0`
+  - `[14:12]` — `pktType` (0 by default)
+  - `[27:16]` — `payload_len` (optional, zero if unused)
+  - `[31]` — `PARITY` (odd parity over bits `[30:0]`)
+- Sender emits a packet only if `N > 0`.
+- Receivers route by ID and consume exactly the host-specified packet count.
+- Versioning note: Any change bumps v2 and requires compatibility handling.

--- a/pl/hls_packet_receiver.cpp
+++ b/pl/hls_packet_receiver.cpp
@@ -19,15 +19,27 @@ unsigned int getPacketId(ap_uint<32> header){
 void hls_packet_receiver(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,hls::stream<axis32_t> &out2,hls::stream<axis32_t> &out3,
         const unsigned int total_num_packet){
         const int packet_limit = static_cast<int>(total_num_packet);
+#ifdef VERIFY_PAYLOAD_LEN
+        static bool payload_len_mismatch = false;
+#endif
         for(int pkt=0; pkt<packet_limit; ++pkt){
                 axis32_t header=in.read();//first word is packet header
                 unsigned int ID=getPacketId(header.data);
                 bool valid_channel = (ID < PACKET_NUM);
 
+                // Packet v1 deframe; consume payload until TLAST; count of packets provided by host.
+#ifdef VERIFY_PAYLOAD_LEN
+                const unsigned expected_len = static_cast<unsigned>(header.data(27,16)) & 0x0FFF;
+                unsigned seen = 0U;
+#endif
+
                 bool last_word=false;
                 do{
                         axis32_t tmp=in.read();
                         last_word = tmp.last;
+#ifdef VERIFY_PAYLOAD_LEN
+                        ++seen;
+#endif
                         if(valid_channel){
                                 switch(ID){
                                 case 0:out0.write(tmp);break;
@@ -38,5 +50,10 @@ void hls_packet_receiver(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,
                                 }
                         }
                 }while(!last_word);
+#ifdef VERIFY_PAYLOAD_LEN
+                if ((expected_len != 0U) && (seen != expected_len) && !payload_len_mismatch) {
+                        payload_len_mismatch = true;
+                }
+#endif
         }
 }


### PR DESCRIPTION
## Summary
- compute packet counts on the host from the max-words array and log the AIE/PL totals
- allow zero-length payloads by guarding channels in the sender, tagging headers with payload length, and recomputing parity
- document packet contract v1 and add optional payload-length verification hooks in both receivers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd734f1718832094e530aa48e829f9