### PR TITLE
Refactor packet sender to consume headers from single stream

### DIFF
--- a/pl/hls_packet_sender.cpp
+++ b/pl/hls_packet_sender.cpp
@@ -1,130 +1,70 @@
 #include "hls_stream.h"
-#include "ap_int.h"
 #include "ap_axi_sdata.h"
-static const unsigned int pktType = 0;
-static const int PACKET_NUM = 6;
-
-static const unsigned int packet_ids[PACKET_NUM] = {0, 1, 2, 3, 4, 5};
+#include "ap_int.h"
 
 typedef ap_axiu<32, 0, 0, 0> axis32_t;
 
-static inline ap_uint<32> generateHeader(unsigned int pktType, unsigned int ID) {
+static inline bool is_aie_id(ap_uint<8> id) {
 #pragma HLS inline
-    ap_uint<32> header = 0;
-    header(7, 0)  = ID;
-    header(11, 8) = 0;
-    header(14,12) = pktType;
-    header[15]    = 0;
-    header(20,16) = (ap_uint<5>)-1; // source row
-    header(27,21) = (ap_uint<7>)-1; // source col
-    header(30,28) = 0;
-    header[31]    = header(30, 0).xor_reduce() ? (ap_uint<1>)0 : (ap_uint<1>)1;
-    return header;
+    return id < 4;
 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wswitch"
-
-// Helper: read exactly one word from channel i
-static inline axis32_t read_from_ch(
-    int i,
-    hls::stream<axis32_t>& s0,
-    hls::stream<axis32_t>& s1,
-    hls::stream<axis32_t>& s2,
-    hls::stream<axis32_t>& s3,
-    hls::stream<axis32_t>& s4,
-    hls::stream<axis32_t>& s5)
-{
+static inline bool is_pl_id(ap_uint<8> id) {
 #pragma HLS inline
-    switch(i){
-        case 0: return s0.read();
-        case 1: return s1.read();
-        case 2: return s2.read();
-        case 3: return s3.read();
-        case 4: return s4.read();
-        default: return s5.read();
-    }
+    return (id >= 4) && (id < 6);
 }
-
-#pragma GCC diagnostic pop
 
 extern "C" void hls_packet_sender(
-    hls::stream<axis32_t>& s0,
-    hls::stream<axis32_t>& s1,
-    hls::stream<axis32_t>& s2,
-    hls::stream<axis32_t>& s3,
-    hls::stream<axis32_t>& s4,
-    hls::stream<axis32_t>& s5,
-    hls::stream<axis32_t>& out,    // → AI Engine (channels 0..3 only)
-    hls::stream<axis32_t>& plout,  // → PL (channels 4..5 only)
-    const unsigned int *max_words_per_ch)
+    hls::stream<axis32_t>& in,
+    hls::stream<axis32_t>& out,
+    hls::stream<axis32_t>& plout,
+    unsigned int total_packets)
 {
-    // ------- Interfaces (good HLS/Versal practice) -------
-    #pragma HLS INTERFACE axis port=s0
-    #pragma HLS INTERFACE axis port=s1
-    #pragma HLS INTERFACE axis port=s2
-    #pragma HLS INTERFACE axis port=s3
-    #pragma HLS INTERFACE axis port=s4
-    #pragma HLS INTERFACE axis port=s5
+    #pragma HLS INTERFACE axis port=in
     #pragma HLS INTERFACE axis port=out
     #pragma HLS INTERFACE axis port=plout
 
-    #pragma HLS INTERFACE m_axi     port=max_words_per_ch  offset=slave depth=PACKET_NUM bundle=gmem0
-    #pragma HLS INTERFACE s_axilite port=max_words_per_ch  bundle=control
+    #pragma HLS INTERFACE s_axilite port=total_packets bundle=control
     #pragma HLS INTERFACE s_axilite port=return bundle=control
 
-    // Make a local copy so the tool can fully partition & schedule well
-    unsigned int words[PACKET_NUM];
-    #pragma HLS ARRAY_PARTITION variable=words complete dim=1
-    load_words: for (int i = 0; i < PACKET_NUM; ++i) {
-        #pragma HLS UNROLL
-        words[i] = max_words_per_ch[i];
-    }
+    packet_loop:
+    for (unsigned int pkt = 0; pkt < total_packets; ++pkt) {
+        axis32_t hdr = in.read();
+        ap_uint<32> hdr_word = hdr.data;
+        ap_uint<8>  id = hdr_word(7, 0);
+        ap_uint<12> payload_len = hdr_word(27, 16);
 
-    // No artificial cross-stream deps; preserve streaming
-    #pragma HLS DATAFLOW disable_start_propagation
+        const bool to_aie = is_aie_id(id);
+        const bool to_pl  = is_pl_id(id);
+        const bool drop   = !(to_aie || to_pl);
 
-    // One contiguous packet per channel:
-    //  header → payload[0..N-1] (TLAST set on last)
-    channel_loop:
-    for (int i = 0; i < PACKET_NUM; ++i) {
-        unsigned int N = words[i];
-        if (N == 0) {
-            continue; // Skip zero-length channels entirely.
-        }
+        axis32_t hdr_out = hdr;
+        hdr_out.keep = -1;
+        hdr_out.last = (payload_len == 0) ? (ap_uint<1>)1 : (ap_uint<1>)0;
 
-        const unsigned int ID = packet_ids[i];
-        const bool to_aie = (ID < 4);
-        const bool to_pl  = (ID >= 4);
-        ap_uint<32>  hdr_word = generateHeader(pktType, ID);
-        hdr_word(27,16) = N & 0x0FFF;
-        hdr_word[31]    = hdr_word(30, 0).xor_reduce() ? (ap_uint<1>)0 : (ap_uint<1>)1;
-
-        // Packet v1: [HEADER(ID,pktType,len,parity)][N payload], TLAST on last. See docs/packet_contract.md
-        axis32_t hdr;
-        hdr.data = hdr_word;
-        hdr.keep = -1;
-        hdr.last = 0;
-
-        if (to_aie) {
-            out.write(hdr);
-        } else if (to_pl) {
-            plout.write(hdr);
+        if (!drop) {
+            if (to_aie) {
+                out.write(hdr_out);
+            } else {
+                plout.write(hdr_out);
+            }
         }
 
         payload_loop:
-        for (unsigned int j = 0; j < N; ++j) {
-            #pragma HLS PIPELINE II=1
-
-            axis32_t d = read_from_ch(i, s0, s1, s2, s3, s4, s5);
+        for (ap_uint<12> idx = 0; idx < payload_len; ++idx) {
+#pragma HLS PIPELINE II=1
+            axis32_t d = in.read();
             d.keep = -1;
-            d.last = (j == (N - 1)) ? (ap_uint<1>)1 : (ap_uint<1>)0;
+            d.last = (idx == payload_len - 1) ? (ap_uint<1>)1 : (ap_uint<1>)0;
 
-            if (to_aie) {
-                out.write(d);
-            } else if (to_pl) {
-                plout.write(d);
+            if (!drop) {
+                if (to_aie) {
+                    out.write(d);
+                } else {
+                    plout.write(d);
+                }
             }
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- replace the individual stream inputs with a single AXI4-Stream header/payload input and add a total packet count control
- parse headers to route payloads to the AI Engine or PL outputs, marking keep/last and dropping unsupported IDs while keeping the payload loop pipelined

## Testing
- not run (requires Vitis HLS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1570288e883208675bbf7c73a552e