### PR TITLE
Update connectivity for aggregated packet streams

### DIFF
--- a/pl/hls_packet_receiver2.cpp
+++ b/pl/hls_packet_receiver2.cpp
@@ -14,43 +14,61 @@ unsigned int getPacketId(ap_uint<32> header){
         return ID;
 }
 
-void hls_packet_receiver2(hls::stream<axis32_t> &in, hls::stream<axis32_t> &out0,hls::stream<axis32_t> &out1,
-        const unsigned int total_num_packet){
-        const int packet_limit = static_cast<int>(total_num_packet);
-#ifdef VERIFY_PAYLOAD_LEN
-        static bool payload_len_mismatch = false;
-#endif
-        for(int pkt=0; pkt<packet_limit; ++pkt){
-                axis32_t header=in.read();//first word is packet header
-                unsigned int ID=getPacketId(header.data);
-                bool valid_channel = (ID == 4u) || (ID == 5u);
+void hls_packet_receiver2(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
+                          const unsigned int total_num_packet) {
+#pragma HLS INTERFACE axis port = in
+#pragma HLS INTERFACE axis port = out
+#pragma HLS INTERFACE s_axilite port = total_num_packet bundle = control
+#pragma HLS INTERFACE s_axilite port = return bundle = control
 
-                // Packet v1 deframe; consume payload until TLAST; count of packets provided by host.
+    const int packet_limit = static_cast<int>(total_num_packet);
 #ifdef VERIFY_PAYLOAD_LEN
-                const unsigned expected_len = static_cast<unsigned>(header.data(27,16)) & 0x0FFF;
-                unsigned seen = 0U;
+    static bool payload_len_mismatch = false;
 #endif
 
-                bool last_word=false;
-                do{
-                        axis32_t tmp=in.read();
-                        last_word = tmp.last;
+    packet_loop:
+    for (int pkt = 0; pkt < packet_limit; ++pkt) {
+        axis32_t header = in.read();
+        const ap_uint<32> header_word = header.data;
+        const ap_uint<8>  id          = static_cast<ap_uint<8>>(getPacketId(header_word));
+        const ap_uint<12> payload_len = header_word(27, 16);
+        const bool        valid_channel = (id == 4u) || (id == 5u);
+        const bool        has_payload   = (header.last == ap_uint<1>(0));
+
 #ifdef VERIFY_PAYLOAD_LEN
-                        ++seen;
+        const unsigned expected_len = static_cast<unsigned>(payload_len);
+        unsigned       seen         = 0U;
 #endif
-                        if(valid_channel){
-                                unsigned int channel = ID - 4u;
-                                switch(channel){
-                                case 0:out0.write(tmp);break;
-                                case 1:out1.write(tmp);break;
-                                default:break;
-                                }
-                        }
-                }while(!last_word);
-#ifdef VERIFY_PAYLOAD_LEN
-                if ((expected_len != 0U) && (seen != expected_len) && !payload_len_mismatch) {
-                        payload_len_mismatch = true;
-                }
-#endif
+
+        if (valid_channel) {
+            axis32_t header_out = header;
+            header_out.keep = -1;
+            header_out.last = has_payload ? ap_uint<1>(0) : ap_uint<1>(1);
+            out.write(header_out);
         }
+
+        bool last_word = !has_payload;
+        if (!last_word) {
+        payload_loop:
+            do {
+#pragma HLS PIPELINE II = 1
+                axis32_t tmp = in.read();
+                last_word     = tmp.last;
+                tmp.keep      = -1;
+
+                if (valid_channel) {
+                    out.write(tmp);
+                }
+#ifdef VERIFY_PAYLOAD_LEN
+                ++seen;
+#endif
+            } while (!last_word);
+        }
+
+#ifdef VERIFY_PAYLOAD_LEN
+        if ((expected_len != 0U) && (seen != expected_len) && !payload_len_mismatch) {
+            payload_len_mismatch = true;
+        }
+#endif
+    }
 }

--- a/system.cfg
+++ b/system.cfg
@@ -1,6 +1,6 @@
 [connectivity]
-nk=s2mm:6:s2mm_1.s2mm_2.s2mm_3.s2mm_4.s2mm_5.s2mm_6
-nk=mm2s:6:mm2s_1.mm2s_2.mm2s_3.mm2s_4.mm2s_5.mm2s_6
+nk=s2mm:2:s2mm_1.s2mm_2
+nk=mm2s:1:mm2s_1
 nk=hls_packet_sender:1:hls_packet_sender_1
 nk=hls_packet_receiver:1:hls_packet_receiver_1
 nk=hls_packet_receiver2:1:hls_packet_receiver_2
@@ -8,22 +8,11 @@ nk=hls_packet_receiver2:1:hls_packet_receiver_2
 stream_connect=hls_packet_sender_1.out:ai_engine_0.Datain0
 stream_connect=ai_engine_0.Dataout0:hls_packet_receiver_1.in
 
-stream_connect=mm2s_1.s:hls_packet_sender_1.s0
-stream_connect=mm2s_2.s:hls_packet_sender_1.s1
-stream_connect=mm2s_3.s:hls_packet_sender_1.s2
-stream_connect=mm2s_4.s:hls_packet_sender_1.s3
-
-stream_connect=mm2s_5.s:hls_packet_sender_1.s4
-stream_connect=mm2s_6.s:hls_packet_sender_1.s5
-
-stream_connect=hls_packet_receiver_1.out0:s2mm_1.s
-stream_connect=hls_packet_receiver_1.out1:s2mm_2.s
-stream_connect=hls_packet_receiver_1.out2:s2mm_3.s
-stream_connect=hls_packet_receiver_1.out3:s2mm_4.s
+stream_connect=mm2s_1.s:hls_packet_sender_1.in
 
 stream_connect=hls_packet_sender_1.plout:hls_packet_receiver_2.in
-stream_connect=hls_packet_receiver_2.out0:s2mm_5.s
-stream_connect=hls_packet_receiver_2.out1:s2mm_6.s
+stream_connect=hls_packet_receiver_1.out:s2mm_1.s
+stream_connect=hls_packet_receiver_2.out:s2mm_2.s
 
 
 [clock]


### PR DESCRIPTION
## Summary
- reduce the mm2s kernel replication and retarget the stream connection to the packet sender's consolidated input port
- collapse the s2mm kernel instances to the aggregated receiver outputs and update the connectivity graph
- refactor the packet receiver HLS kernels to emit single AXI streams with header forwarding and matching interface pragmas

## Testing
- not run (toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1581f4580832081c109e03c0361c9