### PR TITLE
Forward packet headers metadata to output stream

### DIFF
--- a/pl/hls_packet_receiver.cpp
+++ b/pl/hls_packet_receiver.cpp
@@ -5,16 +5,7 @@ SPDX-License-Identifier: MIT
 #include "hls_stream.h"
 #include "ap_int.h"
 #include "ap_axi_sdata.h"
-static const int PACKET_NUM=4;
-
 typedef ap_axiu<32,0,0,0> axis32_t;
-
-unsigned int getPacketId(ap_uint<32> header){
-#pragma HLS inline
-        ap_uint<32> ID=0;
-        ID(7,0)=header(7,0);
-        return ID;
-}
 
 void hls_packet_receiver(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
                          const unsigned int total_num_packet) {
@@ -32,22 +23,18 @@ void hls_packet_receiver(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
     for (int pkt = 0; pkt < packet_limit; ++pkt) {
         axis32_t header = in.read();
         const ap_uint<32> header_word = header.data;
-        const ap_uint<8>  id          = static_cast<ap_uint<8>>(getPacketId(header_word));
         const ap_uint<12> payload_len = header_word(27, 16);
-        const bool        valid_channel = (id < PACKET_NUM);
-        const bool        has_payload   = (header.last == ap_uint<1>(0));
+        const bool        has_payload = (header.last == ap_uint<1>(0));
 
 #ifdef VERIFY_PAYLOAD_LEN
         const unsigned expected_len = static_cast<unsigned>(payload_len);
         unsigned       seen         = 0U;
 #endif
 
-        if (valid_channel) {
-            axis32_t header_out = header;
-            header_out.keep = -1;
-            header_out.last = has_payload ? ap_uint<1>(0) : ap_uint<1>(1);
-            out.write(header_out);
-        }
+        axis32_t header_out = header;
+        header_out.keep = -1;
+        header_out.last = ap_uint<1>(0);
+        out.write(header_out);
 
         bool last_word = !has_payload;
         if (!last_word) {
@@ -56,11 +43,7 @@ void hls_packet_receiver(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
 #pragma HLS PIPELINE II = 1
                 axis32_t tmp = in.read();
                 last_word     = tmp.last;
-                tmp.keep      = -1;
-
-                if (valid_channel) {
-                    out.write(tmp);
-                }
+                out.write(tmp);
 #ifdef VERIFY_PAYLOAD_LEN
                 ++seen;
 #endif


### PR DESCRIPTION
## Summary
- forward packet headers directly to the host stream with keep asserted and last cleared so metadata is visible
- remove channel-based filtering and pass AI Engine payload words through unchanged while keeping their original termination flags
- retain optional payload length checking by counting the forwarded payload words against the header length field

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d15a85a0588320b08fe2eb2f708ae6