### PR TITLE
Mirror header forwarding helper for receiver2

### DIFF
--- a/pl/hls_packet_receiver2.cpp
+++ b/pl/hls_packet_receiver2.cpp
@@ -7,6 +7,18 @@ SPDX-License-Identifier: MIT
 #include "ap_axi_sdata.h"
 typedef ap_axiu<32,0,0,0> axis32_t;
 
+namespace {
+
+axis32_t format_header(axis32_t header_word) {
+#pragma HLS inline
+    axis32_t formatted = header_word;
+    formatted.keep     = -1;
+    formatted.last     = ap_uint<1>(0);
+    return formatted;
+}
+
+} // namespace
+
 void hls_packet_receiver2(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
                           const unsigned int total_num_packet) {
 #pragma HLS INTERFACE axis port = in
@@ -31,10 +43,7 @@ void hls_packet_receiver2(hls::stream<axis32_t>& in, hls::stream<axis32_t>& out,
         unsigned       seen         = 0U;
 #endif
 
-        axis32_t header_out = header;
-        header_out.keep = -1;
-        header_out.last = ap_uint<1>(0);
-        out.write(header_out);
+        out.write(format_header(header));
 
         bool last_word = !has_payload;
         if (!last_word) {


### PR DESCRIPTION
## Summary
- add an inline helper that prepares the packet header so the receiver2 kernel mirrors the single-output behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d15b86b00c83208e6b91076f0fd532