### PR TITLE
Refactor packet flow to single ingress and add adapters

### DIFF
--- a/aie/graph.h
+++ b/aie/graph.h
@@ -1,5 +1,8 @@
 #pragma once
+
 #include <adf.h>
+#include <string>
+
 #include "nn_defs.h"
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
@@ -8,26 +11,8 @@
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;
+using namespace pkt_adapters;
 
-/*
- * Neural Network Graph Implementation for Packet Stream Processing
- *
- * This file implements a two-layer neural network that processes packetized data streams.
- * The design uses Xilinx DSPLib matrix-vector multiplication kernels and custom packet
- * processing to route data between AI Engine and PL domains.
- *
- * DATA FLOW OVERVIEW:
- * 1. Packetized input → Packet splitter (routes by ID: 0-3→AIE, 4-5→PL bypass)
- * 2. AIE path: Packet→Float converter → Dense layers → Float→Packet converter
- * 3. Both paths merge back into single packetized output stream
- *
- * PACKET FORMAT (as per docs/packet_contract.md):
- * - Bits [7:0]:   Packet ID (0-3 for neural network, 4-5 for bypass)
- * - Bits [11:8]:  Reserved (must be 0)
- * - Bits [14:12]: Packet Type (0 by default)
- * - Bits [27:16]: Payload length (optional, 0 if unused)
- * - Bit [31]:     Odd parity over bits [30:0]
- */
 // DSPLib configuration parameters for matrix-vector multiplication
 static constexpr unsigned int TP_SHIFT = 0;              // No bit shifting
 static constexpr unsigned int TP_RND = rnd_floor;        // Round towards negative infinity
@@ -37,6 +22,7 @@ static constexpr unsigned int TP_SSR = 1;                // Single channel (no s
 static constexpr unsigned int TP_DIM_A_LEADING = 1;      // Matrix A is row-major
 static constexpr unsigned int TP_CASC_LEN_LAYER1 = 1;    // Layer 1: Single AIE tile (8x128)
 static constexpr unsigned int TP_CASC_LEN_LAYER2 = 2;    // Layer 2: 2 AIE tiles in cascade (128x128)
+
 // Layer 1: 8-input × 128-hidden dense layer (INPUT_SIZE=8, HIDDEN_SIZE=128)
 // Matrix dimensions: A[128][8] × B[8][1] = C[128][1]
 using dense8x128 = matrix_vector_mul_graph<
@@ -64,181 +50,86 @@ using dense128x128 = matrix_vector_mul_graph<
     TP_SAT,
     TP_SSR,
     TP_DIM_A_LEADING>;
-/*
- * CoreNeuralNetworkGraph: Two-layer neural network without packet processing
- *
- * DATA ROUTING ARCHITECTURE:
- * 1. Input data comes via data_in port (from packet converter)
- * 2. Layer 0 weights loaded from PLIO file at initialization
- * 3. Layer 0 output goes to PLIO file for LeakyReLU processing in PL
- * 4. Layer 1 input comes from PLIO files (post-LeakyReLU data)
- * 5. Layer 1 weights loaded from separate PLIO files per cascade
- * 6. Final output goes via data_out port (to packet converter)
- *
- * WEIGHT AND DATA SPLIT MECHANISM:
- * - Layer 0: Single weight matrix (8x128), single input vector (8x1)
- * - Layer 1: Weight matrix split across 2 cascade tiles (128x128 total)
- * - Layer 1 input also split across 2 cascade inputs for parallel processing
- */
-class CoreNeuralNetworkGraph : public graph {
+
+class NeuralNetworkGraph : public graph {
 public:
-    // Primary data flow ports (connected to packet processing kernels)
-    port<input> data_in;          // 8 floats from packet→float converter
-    port<output> data_out;        // 128 floats to float→packet converter
+    // Packet ingress/egress
+    input_plio  all_in_pkts;
+    output_plio all_out_pkts;
 
-    // PLIO interfaces for weights and intermediate data
-    input_plio layer0_weights;                    // Layer 0 weight matrix [128x8]
-    input_plio layer1_in[TP_CASC_LEN_LAYER2];   // Layer 1 input vectors (post-LeakyReLU)
-    input_plio layer1_weights[TP_CASC_LEN_LAYER2]; // Layer 1 weight matrices (split)
-    output_plio layer0_out;                      // Layer 0 output for PL processing
+    // Packet routing infrastructure
+    pktsplit<6> sp;   // Six downstream packet destinations
+    pktmerge<2> mg;   // Two upstream packet sources
 
-    // Dense layer instances using DSPLib matrix-vector multiplication
-    dense8x128   dense1;          // First layer: 8→128 transformation
-    dense128x128 dense2;          // Second layer: 128→128 transformation
+    // Packet/window adapter kernels
+    kernel k_pkt2win_d1A;
+    kernel k_pkt2win_d1B;
+    kernel k_pkt2win_d2A0;
+    kernel k_pkt2win_d2A1;
+    kernel k_pkt2win_d2B0;
+    kernel k_pkt2win_d2B1;
 
-    CoreNeuralNetworkGraph() {
-        std::string base_path = DATA_DIR;
+    kernel k_win2pkt_d1Y;
+    kernel k_win2pkt_d2Y;
 
-        // Initialize Layer 0 (8x128 dense layer) - Single AIE tile processing
-        layer0_weights = input_plio::create("layer0_weights", plio_32_bits,
-                                          (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
-        layer0_out = output_plio::create("layer0_out", plio_32_bits,
-                                       (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
+    // Dense layers
+    dense8x128   dense1;
+    dense128x128 dense2;
 
-        // Layer 0 connections: weights[128x8] × input[8x1] = output[128x1]
-        connect<>(layer0_weights.out[0], dense1.inA[0]);  // Weight matrix to port A
-        connect<>(data_in, dense1.inB[0]);                // Input vector to port B
-        connect<>(dense1.out[0], layer0_out.in[0]);       // Output to PLIO for LeakyReLU
+    NeuralNetworkGraph() {
+        const std::string base = DATA_DIR;
 
-        // Initialize Layer 1 (128x128 dense layer) - 2 AIE tiles in cascade
-        // Data and weights are split across cascade tiles for parallel processing
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
-            std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
-            std::string in_name = "layer1_in_" + std::to_string(i);
-            std::string w_name  = "layer1_weights_" + std::to_string(i);
+        all_in_pkts  = input_plio ::create("all_in_pkts",  plio_32_bits, (base + "/" + ALL_INPUT_PKTS).c_str());
+        all_out_pkts = output_plio::create("all_out_pkts", plio_32_bits, (base + "/" + ALL_OUTPUT_PKTS).c_str());
 
-            // Create PLIO for each cascade input (post-LeakyReLU data from PL)
-            layer1_in[i] = input_plio::create(in_name.c_str(), plio_32_bits, in_file.c_str());
-            // Create PLIO for each cascade weight matrix partition
-            layer1_weights[i] = input_plio::create(w_name.c_str(), plio_32_bits, w_file.c_str());
+        // Instantiate packet/window adapters
+        k_pkt2win_d1A = kernel::create(pkt_to_win_mat);
+        k_pkt2win_d1B = kernel::create(pkt_to_win_vec);
+        k_pkt2win_d2A0 = kernel::create(pkt_to_win_mat);
+        k_pkt2win_d2A1 = kernel::create(pkt_to_win_mat);
+        k_pkt2win_d2B0 = kernel::create(pkt_to_win_vec);
+        k_pkt2win_d2B1 = kernel::create(pkt_to_win_vec);
 
-            // Connect to cascade tile i: weights[partition_i] × input[partition_i]
-            connect<>(layer1_in[i].out[0], dense2.inB[i]);        // Input vector partition
-            connect<>(layer1_weights[i].out[0], dense2.inA[i]);   // Weight matrix partition
-        }
+        k_win2pkt_d1Y = kernel::create(win_to_pkt_vec_d1);
+        k_win2pkt_d2Y = kernel::create(win_to_pkt_vec_d2);
 
-        // Layer 1 output: Final 128-element result vector goes to packet converter
-        connect<>(dense2.out[0], data_out);
+        source(k_pkt2win_d1A) = "packet_kernels.cpp";
+        source(k_pkt2win_d1B) = "packet_kernels.cpp";
+        source(k_pkt2win_d2A0) = "packet_kernels.cpp";
+        source(k_pkt2win_d2A1) = "packet_kernels.cpp";
+        source(k_pkt2win_d2B0) = "packet_kernels.cpp";
+        source(k_pkt2win_d2B1) = "packet_kernels.cpp";
+        source(k_win2pkt_d1Y) = "packet_kernels.cpp";
+        source(k_win2pkt_d2Y) = "packet_kernels.cpp";
+
+        // Packet routing topology
+        connect<pktstream>(all_in_pkts.out[0], sp.in[0]);
+
+        connect<pktstream>(sp.out[0], k_pkt2win_d1A.in[0]);
+        connect<>(k_pkt2win_d1A.out[0], dense1.inA[0]);
+
+        connect<pktstream>(sp.out[1], k_pkt2win_d1B.in[0]);
+        connect<>(k_pkt2win_d1B.out[0], dense1.inB[0]);
+
+        connect<pktstream>(sp.out[2], k_pkt2win_d2A0.in[0]);
+        connect<>(k_pkt2win_d2A0.out[0], dense2.inA[0]);
+
+        connect<pktstream>(sp.out[3], k_pkt2win_d2A1.in[0]);
+        connect<>(k_pkt2win_d2A1.out[0], dense2.inA[1]);
+
+        connect<pktstream>(sp.out[4], k_pkt2win_d2B0.in[0]);
+        connect<>(k_pkt2win_d2B0.out[0], dense2.inB[0]);
+
+        connect<pktstream>(sp.out[5], k_pkt2win_d2B1.in[0]);
+        connect<>(k_pkt2win_d2B1.out[0], dense2.inB[1]);
+
+        connect<>(dense1.out[0], k_win2pkt_d1Y.in[0]);
+        connect<pktstream>(k_win2pkt_d1Y.out[0], mg.in[0]);
+
+        connect<>(dense2.out[0], k_win2pkt_d2Y.in[0]);
+        connect<pktstream>(k_win2pkt_d2Y.out[0], mg.in[1]);
+
+        connect<pktstream>(mg.out[0], all_out_pkts.in[0]);
     }
 };
 
-/*
- * PacketStreamNeuralNetworkGraph: Complete packet-processing neural network
- *
- * PACKET HEADER EXTRACTION AND ROUTING:
- * - Packet headers are extracted in packet_kernels.cpp:packet_splitter()
- * - Header parsing uses PacketHeader struct methods:
- *   * getPacketID(): Extracts bits [7:0] for routing decision
- *   * getPacketType(): Extracts bits [14:12] for packet classification
- *   * getOddParity(): Extracts bit [31] for error detection
- *
- * ROUTING LOGIC:
- * - Packet ID 0-3: Route to neural network processing path
- * - Packet ID 4-5: Route to bypass path (PL domain)
- * - Each packet contains 8 float payload words after header
- *
- * DATA FLOW THROUGH GRAPH:
- * Input PLIO → pktsplit → [NN path | Bypass path] → pktmerge → Output PLIO
- *              ↓                                       ↑
- *         packet→float                           float→packet
- *              ↓                                       ↑
- *         CoreNN Graph                               CoreNN
- */
-class PacketStreamNeuralNetworkGraph : public graph {
-public:
-    // PLIO interfaces for packetized data streams
-    input_plio combined_input;    // Packetized input stream (header + 8 floats)
-    output_plio combined_output;  // Packetized output stream (header + 8 floats)
-
-    // Single multi-channel packet converter (saves AIE resources)
-    kernel multi_pkt_to_float;    // Handles all 6 channels: pktstream[6] → float[6]
-    kernel multi_float_to_pkt;    // Handles all 6 channels: float[6] → pktstream[6]
-
-    // Core neural network processing
-    CoreNeuralNetworkGraph core_nn;
-
-    // Packet routing infrastructure (uses packet ID for routing to 6 destinations)
-    pktsplit<6> pkt_split;        // Routes packets by ID: 0=dense1_weights, 1=dense2a_weights,
-                                  //                      2=dense2b_weights, 3=dense1_inputs,
-                                  //                      4=dense2a_inputs, 5=dense2b_inputs
-    pktmerge<6> pkt_merge;        // Merges all 6 streams back together
-
-    PacketStreamNeuralNetworkGraph() {
-        std::string base_path = DATA_DIR;
-
-        // Initialize PLIO interfaces for packet streams
-        combined_input = input_plio::create("combined_input", plio_32_bits,
-                                           (base_path + "/" + "combined_input.txt").c_str());
-        combined_output = output_plio::create("combined_output", plio_32_bits,
-                                             (base_path + "/" + "combined_output.txt").c_str());
-
-        // Create single multi-channel packet converters (resource efficient)
-        multi_pkt_to_float = kernel::create(multi_packet_to_float_converter);
-        multi_float_to_pkt = kernel::create(multi_float_to_packet_converter);
-
-        // Link to packet_kernels.cpp
-        source(multi_pkt_to_float) = "packet_kernels.cpp";
-        source(multi_float_to_pkt) = "packet_kernels.cpp";
-
-        // Create packet routing infrastructure for 6 destinations
-        // pktsplit: Hardware packet router that reads packet ID from header
-        // pktmerge: Hardware packet combiner that multiplexes six streams
-        pkt_split = pktsplit<6>::create();
-        pkt_merge = pktmerge<6>::create();
-
-        // STEP 1: Route packets by ID automatically
-        connect<pktstream>(combined_input.out[0], pkt_split.in[0]);
-
-        // STEP 2: Connect all 6 packet streams to single multi-channel converter
-        connect<pktstream>(pkt_split.out[0], multi_pkt_to_float.in[0]);  // ID 0 packets
-        connect<pktstream>(pkt_split.out[1], multi_pkt_to_float.in[1]);  // ID 1 packets
-        connect<pktstream>(pkt_split.out[2], multi_pkt_to_float.in[2]);  // ID 2 packets
-        connect<pktstream>(pkt_split.out[3], multi_pkt_to_float.in[3]);  // ID 3 packets
-        connect<pktstream>(pkt_split.out[4], multi_pkt_to_float.in[4]);  // ID 4 packets
-        connect<pktstream>(pkt_split.out[5], multi_pkt_to_float.in[5]);  // ID 5 packets
-
-        // STEP 3: Connect packet streams directly to neural network layers
-        // NOTE: CoreNeuralNetworkGraph uses PLIO files, so connect directly to dense layer inputs
-
-        // Connect to Dense1 layer inputs (8x128)
-        connect<>(multi_pkt_to_float.out[0], core_nn.dense1.inA[0]);     // Channel 0 → Dense1 weights
-        connect<>(multi_pkt_to_float.out[3], core_nn.dense1.inB[0]);     // Channel 3 → Dense1 inputs
-
-        // Connect to Dense2 layer inputs (128x128 cascade)
-        connect<>(multi_pkt_to_float.out[1], core_nn.dense2.inA[0]);     // Channel 1 → Dense2 weights cascade 0
-        connect<>(multi_pkt_to_float.out[2], core_nn.dense2.inA[1]);     // Channel 2 → Dense2 weights cascade 1
-        connect<>(multi_pkt_to_float.out[4], core_nn.dense2.inB[0]);     // Channel 4 → Dense2 inputs cascade 0
-        connect<>(multi_pkt_to_float.out[5], core_nn.dense2.inB[1]);     // Channel 5 → Dense2 inputs cascade 1
-
-        // STEP 4: Connect neural network outputs to packet converter
-        connect<>(core_nn.dense1.out[0], multi_float_to_pkt.in[0]);      // Dense1 output
-        connect<>(core_nn.dense2.out[0], multi_float_to_pkt.in[1]);      // Dense2 output
-        // Use remaining channels for other data or leave unused
-
-        // STEP 5: Connect all packet outputs to merge
-        connect<pktstream>(multi_float_to_pkt.out[0], pkt_merge.in[0]);  // Channel 0
-        connect<pktstream>(multi_float_to_pkt.out[1], pkt_merge.in[1]);  // Channel 1
-        connect<pktstream>(multi_float_to_pkt.out[2], pkt_merge.in[2]);  // Channel 2
-        connect<pktstream>(multi_float_to_pkt.out[3], pkt_merge.in[3]);  // NN output
-        connect<pktstream>(multi_float_to_pkt.out[4], pkt_merge.in[4]);  // Channel 4
-        connect<pktstream>(multi_float_to_pkt.out[5], pkt_merge.in[5]);  // Channel 5
-
-        connect<pktstream>(pkt_merge.out[0], combined_output.in[0]);  // Final output
-
-        // No runtime ratios needed - using pure hardware packet routing!
-    }
-};
-
-// Legacy typedef for compatibility with existing code
-using NeuralNetworkGraph = PacketStreamNeuralNetworkGraph;

--- a/aie/packet_kernels.cpp
+++ b/aie/packet_kernels.cpp
@@ -1,0 +1,102 @@
+#include "packet_kernels.h"
+
+#include <cstdio>
+
+namespace pkt_adapters {
+
+bool PacketHeader::has_valid_parity() const {
+    return detail::compute_odd_parity(raw);
+}
+
+PacketHeader PacketHeader::build(std::uint8_t id, std::uint16_t payload_words) {
+    std::uint32_t header = static_cast<std::uint32_t>(id & kIdMask);
+    header |= (static_cast<std::uint32_t>(payload_words) & kPayloadMask) << kPayloadShift;
+    header &= ~kParityBitMask;
+
+    const bool base_is_odd = detail::compute_odd_parity(header);
+    if (!base_is_odd) {
+        header |= kParityBitMask;
+    }
+    return PacketHeader{header};
+}
+
+namespace {
+
+inline std::size_t window_word_count(adf::output_window<float>* w) {
+    return window_size(w) / sizeof(float);
+}
+
+inline std::size_t window_word_count(adf::input_window<float>* w) {
+    return window_size(w) / sizeof(float);
+}
+
+void pkt_to_win_common(const char* tag, adf::input_pktstream* s, adf::output_window<float>* w) {
+    const std::uint32_t header_word = readincr(s);
+    const PacketHeader header       = PacketHeader::from_word(header_word);
+    const std::size_t  words        = window_word_count(w);
+
+    detail::log_packet(tag, header.id(), words);
+    if (!header.has_valid_parity()) {
+        printf("%s: parity error (raw=0x%08x)\n", tag, header_word);
+    }
+
+    if (header.payload_words() != 0U && header.payload_words() != words) {
+        printf("%s: payload length mismatch (hdr=%u, expected=%zu)\n", tag, header.payload_words(), words);
+    }
+
+    for (std::size_t i = 0; i < words; ++i) {
+        const std::uint32_t word = readincr(s);
+        const float         val  = detail::bits_to_float(word);
+        window_writeincr(w, val);
+    }
+}
+
+void win_to_pkt_common(const char* tag,
+                       adf::input_window<float>* w,
+                       adf::output_pktstream*   s,
+                       std::uint8_t        out_id) {
+    const std::size_t words = window_word_count(w);
+    const PacketHeader header = PacketHeader::build(out_id, static_cast<std::uint16_t>(words));
+
+    detail::log_packet(tag, out_id, words);
+    writeincr(s, header.raw, false);
+
+    for (std::size_t i = 0; i < words; ++i) {
+        const float         value = window_readincr(w);
+        const std::uint32_t word  = detail::float_to_bits(value);
+        const bool          last  = (i + 1U == words);
+        writeincr(s, word, last);
+    }
+}
+
+}  // namespace
+
+void pkt_to_win_vec(adf::input_pktstream* s, adf::output_window<float>* w) {
+    pkt_to_win_common("pkt_to_win_vec", s, w);
+}
+
+void pkt_to_win_mat(adf::input_pktstream* s, adf::output_window<float>* w) {
+    pkt_to_win_common("pkt_to_win_mat", s, w);
+}
+
+void win_to_pkt_vec(adf::input_window<float>* w, adf::output_pktstream* s, std::uint8_t out_id) {
+    win_to_pkt_common("win_to_pkt_vec", w, s, out_id);
+}
+
+void win_to_pkt_vec_d1(adf::input_window<float>* w, adf::output_pktstream* s) {
+    win_to_pkt_vec(w, s, 16U);
+}
+
+void win_to_pkt_vec_d2(adf::input_window<float>* w, adf::output_pktstream* s) {
+    win_to_pkt_vec(w, s, 17U);
+}
+
+namespace detail {
+
+void log_packet(const char* tag, std::uint8_t id, std::size_t words) {
+    printf("%s: id=%u words=%zu\n", tag, static_cast<unsigned>(id), words);
+}
+
+}  // namespace detail
+
+}  // namespace pkt_adapters

--- a/aie/packet_kernels.h
+++ b/aie/packet_kernels.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <adf.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace pkt_adapters {
+
+struct PacketHeader {
+    static constexpr std::uint32_t kIdMask          = 0x1F;
+    static constexpr std::uint32_t kPayloadShift    = 16;
+    static constexpr std::uint32_t kPayloadMask     = 0x0FFF;
+    static constexpr std::uint32_t kParityBitMask   = 0x80000000u;
+    static constexpr std::uint32_t kPayloadMaskFull = kPayloadMask << kPayloadShift;
+
+    std::uint32_t raw;
+
+    [[nodiscard]] std::uint8_t  id() const { return static_cast<std::uint8_t>(raw & kIdMask); }
+    [[nodiscard]] std::uint16_t payload_words() const {
+        return static_cast<std::uint16_t>((raw >> kPayloadShift) & kPayloadMask);
+    }
+    [[nodiscard]] bool has_valid_parity() const;
+
+    static PacketHeader from_word(std::uint32_t word) { return PacketHeader{word}; }
+    static PacketHeader build(std::uint8_t id, std::uint16_t payload_words);
+};
+
+namespace detail {
+[[nodiscard]] inline bool compute_odd_parity(std::uint32_t value) {
+    const unsigned int bit_count = __builtin_popcount(value);
+    return (bit_count & 0x1U) != 0U;
+}
+
+[[nodiscard]] inline std::uint32_t float_to_bits(float value) {
+    std::uint32_t bits = 0U;
+    std::memcpy(&bits, &value, sizeof(float));
+    return bits;
+}
+
+[[nodiscard]] inline float bits_to_float(std::uint32_t bits) {
+    float value = 0.0f;
+    std::memcpy(&value, &bits, sizeof(float));
+    return value;
+}
+
+void log_packet(const char* tag, std::uint8_t id, std::size_t words);
+
+}  // namespace detail
+
+void pkt_to_win_vec(adf::input_pktstream* s, adf::output_window<float>* w);
+void pkt_to_win_mat(adf::input_pktstream* s, adf::output_window<float>* w);
+void win_to_pkt_vec(adf::input_window<float>* w, adf::output_pktstream* s, std::uint8_t out_id);
+
+// Convenience wrappers with fixed output IDs for graph wiring
+void win_to_pkt_vec_d1(adf::input_window<float>* w, adf::output_pktstream* s);
+void win_to_pkt_vec_d2(adf::input_window<float>* w, adf::output_pktstream* s);
+
+}  // namespace pkt_adapters

--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -17,6 +17,10 @@
 #define EMBED_DENSE1_BIAS           "embed_dense_1_bias.txt"
 #define EMBED_MODEL_OUTPUT           "embed_model_output.txt"
 
+// Packetized neural network IO files ---------------------------------------
+#define ALL_INPUT_PKTS               "all_input_pkts.txt"
+#define ALL_OUTPUT_PKTS              "all_output_pkts.txt"
+
 
 // SUBSOLVER0 graph files --------------------------------------------------
 #define SUBSOLVER0_INPUT_DATA_PREFIX   "solver_0_input_part"

--- a/tests/packet_kernels_test.cpp
+++ b/tests/packet_kernels_test.cpp
@@ -1,0 +1,162 @@
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+#include "aie/packet_kernels.h"
+
+using namespace pkt_adapters;
+
+namespace {
+
+std::vector<std::uint32_t> make_packet(std::uint8_t id, const std::vector<float>& payload) {
+    std::vector<std::uint32_t> words;
+    words.reserve(payload.size() + 1U);
+    const PacketHeader header = PacketHeader::build(id, static_cast<std::uint16_t>(payload.size()));
+    words.push_back(header.raw);
+    for (float value : payload) {
+        words.push_back(detail::float_to_bits(value));
+    }
+    return words;
+}
+
+void assert_close(float a, float b, float tol = 1e-6f) {
+    assert(std::fabs(a - b) <= tol);
+}
+
+}  // namespace
+
+int main() {
+    // pkt_to_win_vec: single packet
+    {
+        std::vector<float> payload = {0.5f, -1.0f, 2.5f, 3.25f};
+        adf::input_pktstream stream(make_packet(1U, payload));
+        adf::output_window<float> window(payload.size());
+
+        pkt_to_win_vec(&stream, &window);
+
+        assert(window.index == payload.size());
+        for (std::size_t i = 0; i < payload.size(); ++i) {
+            assert_close(window.data[i], payload[i]);
+        }
+    }
+
+    // pkt_to_win_mat: ensure generic handling of larger payloads
+    {
+        std::vector<float> payload(10);
+        for (std::size_t i = 0; i < payload.size(); ++i) {
+            payload[i] = static_cast<float>(i) * 0.25f;
+        }
+        auto words = make_packet(4U, payload);
+        adf::input_pktstream stream(words);
+        adf::output_window<float> window(payload.size());
+
+        pkt_to_win_mat(&stream, &window);
+
+        assert(window.index == payload.size());
+        for (std::size_t i = 0; i < payload.size(); ++i) {
+            assert_close(window.data[i], payload[i]);
+        }
+    }
+
+    // win_to_pkt_vec: verify header composition and TLAST propagation
+    {
+        std::vector<float> values = {1.0f, -2.0f, 3.5f};
+        adf::input_window<float>  window(values);
+        adf::output_pktstream     stream;
+
+        win_to_pkt_vec(&window, &stream, 17U);
+
+        assert(stream.words.size() == values.size() + 1U);
+        PacketHeader header = PacketHeader::from_word(stream.words[0]);
+        assert(header.id() == 17U);
+        assert(header.payload_words() == values.size());
+        assert(header.has_valid_parity());
+
+        for (std::size_t i = 0; i < values.size(); ++i) {
+            const std::uint32_t expected = detail::float_to_bits(values[i]);
+            assert(stream.words[i + 1U] == expected);
+        }
+
+        assert(stream.last.size() == stream.words.size());
+        assert(stream.last[0] == false);
+        assert(stream.last[1] == false);
+        assert(stream.last[2] == false);
+        assert(stream.last[3] == true);
+    }
+
+    // Back-to-back packets on single stream
+    {
+        std::vector<float> first_payload  = {4.0f, 5.0f};
+        std::vector<float> second_payload = {-1.5f, 2.25f, 3.75f};
+
+        auto words = make_packet(2U, first_payload);
+        auto more  = make_packet(3U, second_payload);
+        words.insert(words.end(), more.begin(), more.end());
+
+        adf::input_pktstream stream(words);
+        adf::output_window<float> first(first_payload.size());
+        adf::output_window<float> second(second_payload.size());
+
+        pkt_to_win_vec(&stream, &first);
+        pkt_to_win_vec(&stream, &second);
+
+        assert(first.index == first_payload.size());
+        assert(second.index == second_payload.size());
+        for (std::size_t i = 0; i < first_payload.size(); ++i) {
+            assert_close(first.data[i], first_payload[i]);
+        }
+        for (std::size_t i = 0; i < second_payload.size(); ++i) {
+            assert_close(second.data[i], second_payload[i]);
+        }
+    }
+
+    // Multiple win_to_pkt_vec invocations append sequential packets
+    {
+        std::vector<float> values_a = {0.0f, 1.0f};
+        std::vector<float> values_b = {2.0f, 3.0f, 4.0f};
+
+        adf::input_window<float>  window_a(values_a);
+        adf::input_window<float>  window_b(values_b);
+        adf::output_pktstream     stream;
+
+        win_to_pkt_vec(&window_a, &stream, 16U);
+        win_to_pkt_vec(&window_b, &stream, 17U);
+
+        // Expect two packets: headers at positions 0 and values_a.size()+1
+        std::size_t offset = 0;
+        {
+            PacketHeader header = PacketHeader::from_word(stream.words[offset]);
+            assert(header.id() == 16U);
+            assert(header.payload_words() == values_a.size());
+            assert(stream.last[offset] == false);
+            for (std::size_t i = 0; i < values_a.size(); ++i) {
+                assert(stream.words[offset + 1U + i] == detail::float_to_bits(values_a[i]));
+                bool last_flag = stream.last[offset + 1U + i];
+                if (i + 1U == values_a.size()) {
+                    assert(last_flag == true);
+                } else {
+                    assert(last_flag == false);
+                }
+            }
+            offset += values_a.size() + 1U;
+        }
+        {
+            PacketHeader header = PacketHeader::from_word(stream.words[offset]);
+            assert(header.id() == 17U);
+            assert(header.payload_words() == values_b.size());
+            assert(stream.last[offset] == false);
+            for (std::size_t i = 0; i < values_b.size(); ++i) {
+                assert(stream.words[offset + 1U + i] == detail::float_to_bits(values_b[i]));
+                bool last_flag = stream.last[offset + 1U + i];
+                if (i + 1U == values_b.size()) {
+                    assert(last_flag == true);
+                } else {
+                    assert(last_flag == false);
+                }
+            }
+        }
+    }
+
+    return 0;
+}

--- a/tests/stubs/adf.h
+++ b/tests/stubs/adf.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace adf {
+
+struct input_pktstream {
+    std::vector<std::uint32_t> words;
+    std::size_t                index = 0;
+
+    input_pktstream() = default;
+    explicit input_pktstream(std::vector<std::uint32_t> w) : words(std::move(w)) {}
+};
+
+struct output_pktstream {
+    std::vector<std::uint32_t> words;
+    std::vector<bool>          last;
+};
+
+template <typename T>
+struct output_window {
+    std::vector<T> data;
+    std::size_t    index = 0;
+
+    output_window() = default;
+    explicit output_window(std::size_t n) : data(n) {}
+};
+
+template <typename T>
+struct input_window {
+    std::vector<T> data;
+    std::size_t    index = 0;
+
+    input_window() = default;
+    explicit input_window(std::vector<T> values) : data(std::move(values)) {}
+};
+
+inline std::uint32_t readincr(input_pktstream* s) {
+    if (s->index >= s->words.size()) {
+        throw std::out_of_range("readincr past end");
+    }
+    return s->words[s->index++];
+}
+
+inline void writeincr(output_pktstream* s, std::uint32_t word, bool last = false) {
+    s->words.push_back(word);
+    s->last.push_back(last);
+}
+
+template <typename T>
+inline std::size_t window_size(output_window<T>* w) {
+    return w->data.size() * sizeof(T);
+}
+
+template <typename T>
+inline std::size_t window_size(input_window<T>* w) {
+    return w->data.size() * sizeof(T);
+}
+
+inline void window_writeincr(output_window<float>* w, float value) {
+    if (w->index >= w->data.size()) {
+        throw std::out_of_range("window_writeincr past end");
+    }
+    w->data[w->index++] = value;
+}
+
+inline float window_readincr(input_window<float>* w) {
+    if (w->index >= w->data.size()) {
+        throw std::out_of_range("window_readincr past end");
+    }
+    return w->data[w->index++];
+}
+
+}  // namespace adf


### PR DESCRIPTION
## Summary
- collapse the AIE neural-network graph onto a single packet ingress/egress with pktsplit/pktmerge routing into the dense layers
- implement packet/window adapter kernels with parity checking, packet logging, and fixed-ID wrappers for dense outputs
- add host-side stubs and unit tests to validate the packet adapters and define consolidated packet IO file names

## Testing
- g++ -std=c++17 -I. -Itests/stubs -Icommon -Iaie tests/packet_kernels_test.cpp aie/packet_kernels.cpp -o tests/packet_kernels_test
- ./tests/packet_kernels_test
- make aie *(fails: v++ not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2de0d2dd483208fb767f69b187627