### PR TITLE
Implement packet converters and single PLIO routing graph

### DIFF
--- a/aie/graph.h
+++ b/aie/graph.h
@@ -1,5 +1,8 @@
 #pragma once
+
 #include <adf.h>
+#include <string>
+
 #include "nn_defs.h"
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
@@ -9,25 +12,6 @@
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;
 
-/*
- * Neural Network Graph Implementation for Packet Stream Processing
- *
- * This file implements a two-layer neural network that processes packetized data streams.
- * The design uses Xilinx DSPLib matrix-vector multiplication kernels and custom packet
- * processing to route data between AI Engine and PL domains.
- *
- * DATA FLOW OVERVIEW:
- * 1. Packetized input → Packet splitter (routes by ID: 0-3→AIE, 4-5→PL bypass)
- * 2. AIE path: Packet→Float converter → Dense layers → Float→Packet converter
- * 3. Both paths merge back into single packetized output stream
- *
- * PACKET FORMAT (as per docs/packet_contract.md):
- * - Bits [7:0]:   Packet ID (0-3 for neural network, 4-5 for bypass)
- * - Bits [11:8]:  Reserved (must be 0)
- * - Bits [14:12]: Packet Type (0 by default)
- * - Bits [27:16]: Payload length (optional, 0 if unused)
- * - Bit [31]:     Odd parity over bits [30:0]
- */
 // DSPLib configuration parameters for matrix-vector multiplication
 static constexpr unsigned int TP_SHIFT = 0;              // No bit shifting
 static constexpr unsigned int TP_RND = rnd_floor;        // Round towards negative infinity
@@ -37,6 +21,7 @@ static constexpr unsigned int TP_SSR = 1;                // Single channel (no s
 static constexpr unsigned int TP_DIM_A_LEADING = 1;      // Matrix A is row-major
 static constexpr unsigned int TP_CASC_LEN_LAYER1 = 1;    // Layer 1: Single AIE tile (8x128)
 static constexpr unsigned int TP_CASC_LEN_LAYER2 = 2;    // Layer 2: 2 AIE tiles in cascade (128x128)
+
 // Layer 1: 8-input × 128-hidden dense layer (INPUT_SIZE=8, HIDDEN_SIZE=128)
 // Matrix dimensions: A[128][8] × B[8][1] = C[128][1]
 using dense8x128 = matrix_vector_mul_graph<
@@ -46,7 +31,7 @@ using dense8x128 = matrix_vector_mul_graph<
     TP_SHIFT,
     TP_RND,
     TP_NUM_FRAMES,
-    TP_CASC_LEN_LAYER1,          // Single AIE tile
+    TP_CASC_LEN_LAYER1,
     TP_SAT,
     TP_SSR,
     TP_DIM_A_LEADING>;
@@ -60,185 +45,71 @@ using dense128x128 = matrix_vector_mul_graph<
     TP_SHIFT,
     TP_RND,
     TP_NUM_FRAMES,
-    TP_CASC_LEN_LAYER2,          // 2 AIE tiles in cascade for larger computation
+    TP_CASC_LEN_LAYER2,
     TP_SAT,
     TP_SSR,
     TP_DIM_A_LEADING>;
-/*
- * CoreNeuralNetworkGraph: Two-layer neural network without packet processing
- *
- * DATA ROUTING ARCHITECTURE:
- * 1. Input data comes via data_in port (from packet converter)
- * 2. Layer 0 weights loaded from PLIO file at initialization
- * 3. Layer 0 output goes to PLIO file for LeakyReLU processing in PL
- * 4. Layer 1 input comes from PLIO files (post-LeakyReLU data)
- * 5. Layer 1 weights loaded from separate PLIO files per cascade
- * 6. Final output goes via data_out port (to packet converter)
- *
- * WEIGHT AND DATA SPLIT MECHANISM:
- * - Layer 0: Single weight matrix (8x128), single input vector (8x1)
- * - Layer 1: Weight matrix split across 2 cascade tiles (128x128 total)
- * - Layer 1 input also split across 2 cascade inputs for parallel processing
- */
+
 class CoreNeuralNetworkGraph : public graph {
 public:
-    // Primary data flow ports (connected to packet processing kernels)
-    port<input> data_in;          // 8 floats from packet→float converter
-    port<output> data_out;        // 128 floats to float→packet converter
-
-    // PLIO interfaces for weights and intermediate data
-    input_plio layer0_weights;                    // Layer 0 weight matrix [128x8]
-    input_plio layer1_in[TP_CASC_LEN_LAYER2];   // Layer 1 input vectors (post-LeakyReLU)
-    input_plio layer1_weights[TP_CASC_LEN_LAYER2]; // Layer 1 weight matrices (split)
-    output_plio layer0_out;                      // Layer 0 output for PL processing
-
-    // Dense layer instances using DSPLib matrix-vector multiplication
     dense8x128   dense1;          // First layer: 8→128 transformation
     dense128x128 dense2;          // Second layer: 128→128 transformation
 
-    CoreNeuralNetworkGraph() {
-        std::string base_path = DATA_DIR;
-
-        // Initialize Layer 0 (8x128 dense layer) - Single AIE tile processing
-        layer0_weights = input_plio::create("layer0_weights", plio_32_bits,
-                                          (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
-        layer0_out = output_plio::create("layer0_out", plio_32_bits,
-                                       (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
-
-        // Layer 0 connections: weights[128x8] × input[8x1] = output[128x1]
-        connect<>(layer0_weights.out[0], dense1.inA[0]);  // Weight matrix to port A
-        connect<>(data_in, dense1.inB[0]);                // Input vector to port B
-        connect<>(dense1.out[0], layer0_out.in[0]);       // Output to PLIO for LeakyReLU
-
-        // Initialize Layer 1 (128x128 dense layer) - 2 AIE tiles in cascade
-        // Data and weights are split across cascade tiles for parallel processing
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
-            std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
-            std::string in_name = "layer1_in_" + std::to_string(i);
-            std::string w_name  = "layer1_weights_" + std::to_string(i);
-
-            // Create PLIO for each cascade input (post-LeakyReLU data from PL)
-            layer1_in[i] = input_plio::create(in_name.c_str(), plio_32_bits, in_file.c_str());
-            // Create PLIO for each cascade weight matrix partition
-            layer1_weights[i] = input_plio::create(w_name.c_str(), plio_32_bits, w_file.c_str());
-
-            // Connect to cascade tile i: weights[partition_i] × input[partition_i]
-            connect<>(layer1_in[i].out[0], dense2.inB[i]);        // Input vector partition
-            connect<>(layer1_weights[i].out[0], dense2.inA[i]);   // Weight matrix partition
-        }
-
-        // Layer 1 output: Final 128-element result vector goes to packet converter
-        connect<>(dense2.out[0], data_out);
-    }
+    CoreNeuralNetworkGraph() = default;
 };
 
-/*
- * PacketStreamNeuralNetworkGraph: Complete packet-processing neural network
- *
- * PACKET HEADER EXTRACTION AND ROUTING:
- * - Packet headers are extracted in packet_kernels.cpp:packet_splitter()
- * - Header parsing uses PacketHeader struct methods:
- *   * getPacketID(): Extracts bits [7:0] for routing decision
- *   * getPacketType(): Extracts bits [14:12] for packet classification
- *   * getOddParity(): Extracts bit [31] for error detection
- *
- * ROUTING LOGIC:
- * - Packet ID 0-3: Route to neural network processing path
- * - Packet ID 4-5: Route to bypass path (PL domain)
- * - Each packet contains 8 float payload words after header
- *
- * DATA FLOW THROUGH GRAPH:
- * Input PLIO → pktsplit → [NN path | Bypass path] → pktmerge → Output PLIO
- *              ↓                                       ↑
- *         packet→float                           float→packet
- *              ↓                                       ↑
- *         CoreNN Graph                               CoreNN
- */
+static const std::string COMBINED_INPUT_PATH  = std::string(DATA_DIR) + "/combined_input.txt";
+static const std::string COMBINED_OUTPUT_PATH = std::string(DATA_DIR) + "/combined_output.txt";
+
 class PacketStreamNeuralNetworkGraph : public graph {
 public:
-    // PLIO interfaces for packetized data streams
-    input_plio combined_input;    // Packetized input stream (header + 8 floats)
-    output_plio combined_output;  // Packetized output stream (header + 8 floats)
+    input_plio  combined_input;
+    output_plio combined_output;
 
-    // Single multi-channel packet converter (saves AIE resources)
-    kernel multi_pkt_to_float;    // Handles all 6 channels: pktstream[6] → float[6]
-    kernel multi_float_to_pkt;    // Handles all 6 channels: float[6] → pktstream[6]
+    kernel multi_pkt_to_float;
+    kernel multi_float_to_pkt;
 
-    // Core neural network processing
     CoreNeuralNetworkGraph core_nn;
 
-    // Packet routing infrastructure (uses packet ID for routing to 6 destinations)
-    pktsplit<6> pkt_split;        // Routes packets by ID: 0=dense1_weights, 1=dense2a_weights,
-                                  //                      2=dense2b_weights, 3=dense1_inputs,
-                                  //                      4=dense2a_inputs, 5=dense2b_inputs
-    pktmerge<6> pkt_merge;        // Merges all 6 streams back together
+    pktsplit<6> pkt_split;
+    pktmerge<2> pkt_merge;
 
-    PacketStreamNeuralNetworkGraph() {
-        std::string base_path = DATA_DIR;
-
-        // Initialize PLIO interfaces for packet streams
-        combined_input = input_plio::create("combined_input", plio_32_bits,
-                                           (base_path + "/" + "combined_input.txt").c_str());
-        combined_output = output_plio::create("combined_output", plio_32_bits,
-                                             (base_path + "/" + "combined_output.txt").c_str());
-
-        // Create single multi-channel packet converters (resource efficient)
+    PacketStreamNeuralNetworkGraph()
+        : combined_input("combined_input", plio_32_bits, COMBINED_INPUT_PATH.c_str()),
+          combined_output("combined_output", plio_32_bits, COMBINED_OUTPUT_PATH.c_str()) {
         multi_pkt_to_float = kernel::create(multi_packet_to_float_converter);
         multi_float_to_pkt = kernel::create(multi_float_to_packet_converter);
 
-        // Link to packet_kernels.cpp
         source(multi_pkt_to_float) = "packet_kernels.cpp";
         source(multi_float_to_pkt) = "packet_kernels.cpp";
 
-        // Create packet routing infrastructure for 6 destinations
-        // pktsplit: Hardware packet router that reads packet ID from header
-        // pktmerge: Hardware packet combiner that multiplexes six streams
-        pkt_split = pktsplit<6>::create();
-        pkt_merge = pktmerge<6>::create();
+        runtime<ratio>(multi_pkt_to_float) = 1;
+        runtime<ratio>(multi_float_to_pkt) = 1;
 
-        // STEP 1: Route packets by ID automatically
         connect<pktstream>(combined_input.out[0], pkt_split.in[0]);
 
-        // STEP 2: Connect all 6 packet streams to single multi-channel converter
-        connect<pktstream>(pkt_split.out[0], multi_pkt_to_float.in[0]);  // ID 0 packets
-        connect<pktstream>(pkt_split.out[1], multi_pkt_to_float.in[1]);  // ID 1 packets
-        connect<pktstream>(pkt_split.out[2], multi_pkt_to_float.in[2]);  // ID 2 packets
-        connect<pktstream>(pkt_split.out[3], multi_pkt_to_float.in[3]);  // ID 3 packets
-        connect<pktstream>(pkt_split.out[4], multi_pkt_to_float.in[4]);  // ID 4 packets
-        connect<pktstream>(pkt_split.out[5], multi_pkt_to_float.in[5]);  // ID 5 packets
+        connect<pktstream>(pkt_split.out[0], multi_pkt_to_float.in[0]); // PID 0: D1 weights
+        connect<pktstream>(pkt_split.out[1], multi_pkt_to_float.in[1]); // PID 1: D2 weights (casc0)
+        connect<pktstream>(pkt_split.out[2], multi_pkt_to_float.in[2]); // PID 2: D2 weights (casc1)
+        connect<pktstream>(pkt_split.out[3], multi_pkt_to_float.in[3]); // PID 3: D1 input vector
+        connect<pktstream>(pkt_split.out[4], multi_pkt_to_float.in[4]); // PID 4: D2 input (casc0)
+        connect<pktstream>(pkt_split.out[5], multi_pkt_to_float.in[5]); // PID 5: D2 input (casc1)
 
-        // STEP 3: Connect packet streams directly to neural network layers
-        // NOTE: CoreNeuralNetworkGraph uses PLIO files, so connect directly to dense layer inputs
+        connect<>(multi_pkt_to_float.out[0], core_nn.dense1.inA[0]); // 1024 floats
+        connect<>(multi_pkt_to_float.out[1], core_nn.dense2.inA[0]); // 8192 floats (casc0 weights)
+        connect<>(multi_pkt_to_float.out[2], core_nn.dense2.inA[1]); // 8192 floats (casc1 weights)
+        connect<>(multi_pkt_to_float.out[3], core_nn.dense1.inB[0]); // 8 floats
+        connect<>(multi_pkt_to_float.out[4], core_nn.dense2.inB[0]); // 64 floats (casc0 vector slice)
+        connect<>(multi_pkt_to_float.out[5], core_nn.dense2.inB[1]); // 64 floats (casc1 vector slice)
 
-        // Connect to Dense1 layer inputs (8x128)
-        connect<>(multi_pkt_to_float.out[0], core_nn.dense1.inA[0]);     // Channel 0 → Dense1 weights
-        connect<>(multi_pkt_to_float.out[3], core_nn.dense1.inB[0]);     // Channel 3 → Dense1 inputs
+        connect<>(core_nn.dense1.out[0], multi_float_to_pkt.in[0]);   // Dense1 output (128 floats)
+        connect<>(core_nn.dense2.out[0], multi_float_to_pkt.in[1]);   // Dense2 output (128 floats)
 
-        // Connect to Dense2 layer inputs (128x128 cascade)
-        connect<>(multi_pkt_to_float.out[1], core_nn.dense2.inA[0]);     // Channel 1 → Dense2 weights cascade 0
-        connect<>(multi_pkt_to_float.out[2], core_nn.dense2.inA[1]);     // Channel 2 → Dense2 weights cascade 1
-        connect<>(multi_pkt_to_float.out[4], core_nn.dense2.inB[0]);     // Channel 4 → Dense2 inputs cascade 0
-        connect<>(multi_pkt_to_float.out[5], core_nn.dense2.inB[1]);     // Channel 5 → Dense2 inputs cascade 1
+        connect<pktstream>(multi_float_to_pkt.out[0], pkt_merge.in[0]); // ID 10
+        connect<pktstream>(multi_float_to_pkt.out[1], pkt_merge.in[1]); // ID 11
 
-        // STEP 4: Connect neural network outputs to packet converter
-        connect<>(core_nn.dense1.out[0], multi_float_to_pkt.in[0]);      // Dense1 output
-        connect<>(core_nn.dense2.out[0], multi_float_to_pkt.in[1]);      // Dense2 output
-        // Use remaining channels for other data or leave unused
-
-        // STEP 5: Connect all packet outputs to merge
-        connect<pktstream>(multi_float_to_pkt.out[0], pkt_merge.in[0]);  // Channel 0
-        connect<pktstream>(multi_float_to_pkt.out[1], pkt_merge.in[1]);  // Channel 1
-        connect<pktstream>(multi_float_to_pkt.out[2], pkt_merge.in[2]);  // Channel 2
-        connect<pktstream>(multi_float_to_pkt.out[3], pkt_merge.in[3]);  // NN output
-        connect<pktstream>(multi_float_to_pkt.out[4], pkt_merge.in[4]);  // Channel 4
-        connect<pktstream>(multi_float_to_pkt.out[5], pkt_merge.in[5]);  // Channel 5
-
-        connect<pktstream>(pkt_merge.out[0], combined_output.in[0]);  // Final output
-
-        // No runtime ratios needed - using pure hardware packet routing!
+        connect<pktstream>(pkt_merge.out[0], combined_output.in[0]);
     }
 };
 
-// Legacy typedef for compatibility with existing code
 using NeuralNetworkGraph = PacketStreamNeuralNetworkGraph;

--- a/aie/packet_kernels.cpp
+++ b/aie/packet_kernels.cpp
@@ -1,0 +1,125 @@
+#include "packet_kernels.h"
+
+#include <aie_api/aie.hpp>
+#include <aie_api/aie_adf.hpp>
+#include <algorithm>
+
+namespace {
+
+struct PacketHeader {
+    uint32_t raw;
+
+    explicit PacketHeader(uint32_t value = 0) : raw(value) {}
+
+    uint8_t id() const { return static_cast<uint8_t>(raw & 0xFFu); }
+    uint8_t type() const { return static_cast<uint8_t>((raw >> 12) & 0x7u); }
+    uint16_t length() const { return static_cast<uint16_t>((raw >> 16) & 0x0FFFu); }
+    bool has_odd_parity() const { return (__builtin_popcount(raw) & 1) == 1; }
+};
+
+inline uint32_t set_odd_parity(uint32_t word) {
+    uint32_t masked = word & 0x7FFFFFFFu; // Clear parity bit
+    if ((__builtin_popcount(masked) & 1) == 0) {
+        masked |= 0x80000000u; // Force odd parity
+    }
+    return masked;
+}
+
+inline uint32_t make_header(uint8_t id, uint8_t type, uint16_t len) {
+    uint32_t word = static_cast<uint32_t>(id);
+    word |= static_cast<uint32_t>(type & 0x7u) << 12;
+    word |= static_cast<uint32_t>(len & 0x0FFFu) << 16;
+    return set_odd_parity(word);
+}
+
+inline float word_to_float(uint32_t word) {
+    union {
+        uint32_t u;
+        float f;
+    } conv;
+    conv.u = word;
+    return conv.f;
+}
+
+inline uint32_t float_to_word(float value) {
+    union {
+        float f;
+        uint32_t u;
+    } conv;
+    conv.f = value;
+    return conv.u;
+}
+
+inline uint32_t read_word(input_pktstream* in) { return readincr(in); }
+inline void write_word(output_pktstream* out, uint32_t word) { writeincr(out, word); }
+
+void consume_packet(input_pktstream* in, output_window<float>* out, uint8_t expected_id, uint16_t expected_len) {
+    PacketHeader header(read_word(in));
+
+    uint16_t payload_words = header.length();
+    if (payload_words != expected_len) {
+        payload_words = std::min<uint16_t>(payload_words, expected_len);
+    }
+
+    uint16_t words_written = 0;
+    while (words_written < payload_words) {
+        uint32_t raw = read_word(in);
+        PacketHeader maybe_header(raw);
+        if (maybe_header.type() == PACKET_TYPE_TLAST && maybe_header.id() == expected_id &&
+            maybe_header.length() == 0 && maybe_header.has_odd_parity()) {
+            continue; // Skip TLAST marker
+        }
+
+        float value = word_to_float(raw);
+        window_writeincr(out, value);
+        ++words_written;
+    }
+
+    while (words_written < expected_len) {
+        uint32_t raw = read_word(in);
+        float value = word_to_float(raw);
+        window_writeincr(out, value);
+        ++words_written;
+    }
+}
+
+void emit_packet(input_window<float>* in, output_pktstream* out, uint8_t id, uint16_t length) {
+    write_word(out, make_header(id, PACKET_TYPE_DATA, length));
+
+    for (uint16_t i = 0; i < length; ++i) {
+        if (i == length - 1) {
+            write_word(out, make_header(id, PACKET_TYPE_TLAST, 0));
+        }
+        uint32_t raw = float_to_word(window_readincr(in));
+        write_word(out, raw);
+    }
+}
+
+} // namespace
+
+void multi_packet_to_float_converter(
+    input_pktstream* in0, input_pktstream* in1, input_pktstream* in2,
+    input_pktstream* in3, input_pktstream* in4, input_pktstream* in5,
+    output_window<float>* d1_wt,
+    output_window<float>* d2a_wt,
+    output_window<float>* d2b_wt,
+    output_window<float>* d1_x,
+    output_window<float>* d2a_x,
+    output_window<float>* d2b_x) {
+    consume_packet(in0, d1_wt, PACKET_ID_D1_WEIGHTS, D1_WEIGHTS_WORDS);
+    consume_packet(in1, d2a_wt, PACKET_ID_D2A_WEIGHTS, D2_WEIGHTS_PART_WORDS);
+    consume_packet(in2, d2b_wt, PACKET_ID_D2B_WEIGHTS, D2_WEIGHTS_PART_WORDS);
+    consume_packet(in3, d1_x, PACKET_ID_D1_INPUT, D1_INPUT_WORDS);
+    consume_packet(in4, d2a_x, PACKET_ID_D2A_INPUT, D2_INPUT_PART_WORDS);
+    consume_packet(in5, d2b_x, PACKET_ID_D2B_INPUT, D2_INPUT_PART_WORDS);
+}
+
+void multi_float_to_packet_converter(
+    input_window<float>* d1_y,
+    input_window<float>* d2_y,
+    output_pktstream* out0,
+    output_pktstream* out1) {
+    emit_packet(d1_y, out0, PACKET_ID_D1_OUTPUT, DENSE_OUTPUT_WORDS);
+    emit_packet(d2_y, out1, PACKET_ID_D2_OUTPUT, DENSE_OUTPUT_WORDS);
+}
+

--- a/aie/packet_kernels.h
+++ b/aie/packet_kernels.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <adf.h>
+#include <cstdint>
+
+#include "nn_defs.h"
+
+constexpr uint8_t PACKET_TYPE_DATA = 0;
+constexpr uint8_t PACKET_TYPE_TLAST = 2;
+
+constexpr uint8_t PACKET_ID_D1_WEIGHTS = 0;
+constexpr uint8_t PACKET_ID_D2A_WEIGHTS = 1;
+constexpr uint8_t PACKET_ID_D2B_WEIGHTS = 2;
+constexpr uint8_t PACKET_ID_D1_INPUT   = 3;
+constexpr uint8_t PACKET_ID_D2A_INPUT  = 4;
+constexpr uint8_t PACKET_ID_D2B_INPUT  = 5;
+
+constexpr uint8_t PACKET_ID_D1_OUTPUT = 10;
+constexpr uint8_t PACKET_ID_D2_OUTPUT = 11;
+
+constexpr uint16_t D1_WEIGHTS_WORDS = EMBED_DENSE0_WEIGHTS_SIZE;
+constexpr uint16_t D2_WEIGHTS_PART_WORDS = EMBED_DENSE1_WEIGHTS_PART_SIZE;
+constexpr uint16_t D1_INPUT_WORDS = EMBED_DENSE0_INPUT_SIZE;
+constexpr uint16_t D2_INPUT_PART_WORDS = HIDDEN_SIZE / CASCADE_LENGTH;
+constexpr uint16_t DENSE_OUTPUT_WORDS = OUTPUT_SIZE;
+
+void multi_packet_to_float_converter(
+    input_pktstream* in0, input_pktstream* in1, input_pktstream* in2,
+    input_pktstream* in3, input_pktstream* in4, input_pktstream* in5,
+    output_window<float>* d1_wt,
+    output_window<float>* d2a_wt,
+    output_window<float>* d2b_wt,
+    output_window<float>* d1_x,
+    output_window<float>* d2a_x,
+    output_window<float>* d2b_x);
+
+void multi_float_to_packet_converter(
+    input_window<float>* d1_y,
+    input_window<float>* d2_y,
+    output_pktstream* out0,
+    output_pktstream* out1);
+


### PR DESCRIPTION
## Summary
- expose the DSPLib dense layers directly in `CoreNeuralNetworkGraph` and build a single-input/single-output top graph with pktsplit/pktmerge routing
- add packet conversion helper declarations plus a multi-channel packet-to-float kernel that fills the dense layer windows from the PL packet IDs
- implement the reverse float-to-packet kernel that emits headers with parity and TLAST markers before merging into the combined PLIO output

## Testing
- `make aie` *(fails: `v++: not found` in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2f68a345c83208777cb2049a8bc7c