### PR TITLE
Refactor aieml4 graph to use windowed activations

### DIFF
--- a/aieml4/graph.h
+++ b/aieml4/graph.h
@@ -15,8 +15,9 @@ static constexpr unsigned int TP_NUM_FRAMES = 1;
 static constexpr unsigned int TP_SAT = 0;
 static constexpr unsigned int TP_SSR = 1;
 static constexpr unsigned int TP_DIM_A_LEADING = 1;
+static constexpr unsigned int TP_KERNEL_API = 1;
 static constexpr unsigned int TP_CASC_LEN_LAYER1 = 1;
-static constexpr unsigned int TP_CASC_LEN_LAYER2 = 2;
+static constexpr unsigned int TP_CASC_LEN_LAYER2 = 1;
 using dense8x128 = matrix_vector_mul_graph<
     float, float,
     HIDDEN_SIZE,
@@ -25,6 +26,7 @@ using dense8x128 = matrix_vector_mul_graph<
     TP_RND,
     TP_NUM_FRAMES,
     TP_CASC_LEN_LAYER1,
+    TP_KERNEL_API,
     TP_SAT,
     TP_SSR,
     TP_DIM_A_LEADING>;
@@ -38,6 +40,7 @@ using dense128x128 = matrix_vector_mul_graph<
     TP_RND,
     TP_NUM_FRAMES,
     TP_CASC_LEN_LAYER2,
+    TP_KERNEL_API,
     TP_SAT,
     TP_SSR,
     TP_DIM_A_LEADING>;
@@ -47,12 +50,9 @@ class NeuralNetworkGraph : public graph {
 public:
     input_plio  layer0_in;
     input_plio  layer0_weights;
-    // Output of first dense layer exposed via PLIO for direct PL interfacing
-    output_plio layer0_out;
     dense8x128   dense1;
     dense128x128 dense2;
-    input_plio  layer1_in[TP_CASC_LEN_LAYER2];
-    input_plio  layer1_weights[TP_CASC_LEN_LAYER2];
+    input_plio  layer1_weights;
     // Final dense layer output directly drives a PLIO
     output_plio layer1_out;
     kernel       k_lrelu0;
@@ -62,33 +62,27 @@ public:
         std::string base_path = DATA_DIR;
         layer0_in      = input_plio::create("layer0_in", plio_32_bits, (base_path + "/" + EMBED_INPUT_DATA).c_str());
         layer0_weights = input_plio::create("layer0_weights", plio_32_bits, (base_path + "/" + EMBED_DENSE0_WEIGHTS).c_str());
-        layer0_out     = output_plio::create("layer0_out", plio_32_bits, (base_path + "/" + EMBED_DENSE0_OUTPUT).c_str());
         connect<>(layer0_weights.out[0], dense1.inA[0]);
-        connect<>(layer0_in.out[0], dense1.inB[0]);
-        // connect<>(dense1.out[0], layer0_out.in[0]);
+        connect<window<INPUT_SIZE * sizeof(float)>>(layer0_in.out[0], dense1.inB[0]);
 
         k_lrelu0 = kernel::create(leaky_relu_kernel);
         source(k_lrelu0) = "leaky_relu.cpp";
         headers(k_lrelu0) = {"leaky_relu.h"};
 
         runtime<ratio>(k_lrelu0) = 0.8;
-        connect<>(dense1.out[0], k_lrelu0.in[0]);
-        connect<>(k_lrelu0.out[0], layer0_out.in[0]);
+        connect<window<HIDDEN_SIZE * sizeof(float)>>(dense1.out[0], k_lrelu0.in[0]);
         dimensions(k_lrelu0.in[0])  = { HIDDEN_SIZE };
         dimensions(k_lrelu0.out[0]) = { HIDDEN_SIZE };
 
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            std::string in_file = base_path + "/" + EMBED_LEAKYRELU0_OUTPUT_PREFIX + std::to_string(i) + ".txt";
-            std::string w_file  = base_path + "/" + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(i) + ".txt";
-            std::string in_name = "layer1_in_" + std::to_string(i);
-            std::string w_name  = "layer1_weights_" + std::to_string(i);
-            layer1_in[i]      = input_plio::create(in_name.c_str(), plio_32_bits, in_file.c_str());
-            layer1_weights[i] = input_plio::create(w_name.c_str(), plio_32_bits, w_file.c_str());
-            connect<>(layer1_in[i].out[0], dense2.inB[i]);
-            connect<>(layer1_weights[i].out[0], dense2.inA[i]);
-        }
-        layer1_out = output_plio::create("layer1_out", plio_32_bits, (base_path + "/" + EMBED_DENSE1_OUTPUT).c_str());
-        connect<>(dense2.out[0], layer1_out.in[0]);
+        layer1_weights = input_plio::create("layer1_weights", plio_32_bits,
+                                            (base_path + "/" + EMBED_DENSE1_WEIGHTS).c_str());
+        connect<>(layer1_weights.out[0], dense2.inA[0]);
+
+        connect<window<HIDDEN_SIZE * sizeof(float)>>(k_lrelu0.out[0], dense2.inB[0]);
+
+        layer1_out = output_plio::create("layer1_out", plio_32_bits,
+                                         (base_path + "/" + EMBED_MODEL_OUTPUT).c_str());
+        connect<window<OUTPUT_SIZE * sizeof(float)>>(dense2.out[0], layer1_out.in[0]);
 
     }
 };

--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -11,6 +11,7 @@
 #define EMBED_DENSE0_WEIGHTS        "embed_dense_0_weights.txt"
 #define EMBED_DENSE0_OUTPUT         "embed_dense_0_output_aie.txt"
 #define EMBED_LEAKYRELU0_OUTPUT_PREFIX "embed_leakyrelu_0_output_part"
+#define EMBED_DENSE1_WEIGHTS        "embed_dense_1_weights.txt"
 #define EMBED_DENSE1_WEIGHTS_PREFIX "embed_dense_1_weights_part"
 #define EMBED_DENSE1_OUTPUT         "embed_dense_1_output_aie.txt"
 #define EMBED_DENSE0_BIAS           "embed_dense_0_bias.txt"


### PR DESCRIPTION
## Summary
- switch the aieml4 dense layer cascade to the window-based API
- remove intermediate PLIO staging for leaky ReLU outputs and collapse the solver weights to a single port
- add a shared constant for the consolidated weight file path

## Testing
- `make sim` *(fails: Vitis DSP library path ../dsp_lib missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4176a40e08320b7576681f8ef8e82