### PR TITLE
Fix RTP port hookup for matrix weights

### DIFF
--- a/aieml5/graph.cpp
+++ b/aieml5/graph.cpp
@@ -30,8 +30,8 @@ int main() {
     return -1;
   }
 
-  // Update RTP with weight data
-  g.dense1.update(g.dense1.matrixA[0], weights.data(), EMBED_DENSE0_WEIGHTS_SIZE);
+  // Update RTP with weight data using exposed graph-level parameter port
+  g.update(g.matrixA_rtp, weights.data(), EMBED_DENSE0_WEIGHTS_SIZE);
 
   g.run(1);
   g.wait();

--- a/aieml5/graph.h
+++ b/aieml5/graph.h
@@ -36,7 +36,7 @@ public:
     input_plio  layer0_in;
     output_plio layer0_out;
     dense8x128   dense1;
-    adf::port<adf::direction::in> value;
+    input_port matrixA_rtp;
 
 
     NeuralNetworkGraph() {
@@ -46,7 +46,7 @@ public:
 
         // Matrix A is provided via RTP (runtime parameter) - no PLIO connection needed
         // Vector B uses stream interface with TP_API=1
-        adf::connect<adf::parameter>(value, adf::async(dense1.inA[0]));
+        adf::connect<adf::parameter>(matrixA_rtp, adf::async(dense1.inA[0]));
 
         connect<stream>(layer0_in.out[0], dense1.inB[0]);
         connect<stream>(dense1.out[0], layer0_out.in[0]);


### PR DESCRIPTION
## Summary
- expose the matrix A runtime-parameter port from the aieml5 graph using an input_port, per the AI Engine programming guidance
- connect the graph-level RTP port to the matrix-vector unit and update it from main via graph::update

## Testing
- `make -C aieml5 sim` *(fails: DSP library path ../dsp_lib is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5862462ac8320b545174f33d751af