### PR TITLE
Fix packet streaming kernels to terminate per iteration

### DIFF
--- a/aieml5/graph.cpp
+++ b/aieml5/graph.cpp
@@ -1,6 +1,7 @@
 #include "graph.h"
 #include <fstream>
 #include <iostream>
+#include <string>
 #include <vector>
 
 NeuralNetworkGraph g;
@@ -10,13 +11,13 @@ int main() {
   g.init();
 
   // Load weights from file for RTP
-  // std::string weight_file = std::string(DATA_DIR) + "/" + EMBED_DENSE0_WEIGHTS;
-  std::ifstream file("/home/synthara/VersalPrjs/LDRD/rtda_demo/data/embed_dense_0_weights.txt");
+  std::string weight_file = std::string(DATA_DIR) + "/" + EMBED_DENSE0_WEIGHTS;
+  std::ifstream file(weight_file);
   std::vector<float> weights;
   float weight;
 
   if (!file.is_open()) {
-    std::cerr << "\n\n!!!!!!Error: Could not open weight file " << "!!!!!!!!\\n" << std::endl;
+    std::cerr << "\n\n!!!!!!Error: Could not open weight file " << weight_file << "!!!!!!!!\\n" << std::endl;
     return -1;
   }
 

--- a/aieml5/packetize.cpp
+++ b/aieml5/packetize.cpp
@@ -12,19 +12,17 @@ constexpr unsigned LEN      = EMBED_DENSE0_INPUT_SIZE;
 
 void packetize_kernel(input_stream<float>*  in_stream,
                       output_pktstream*     out_pkt) {
-  while (true) {
-    // Discover the router-assigned packet ID for this output branch
-    uint32_t id = getPacketid(out_pkt, /*index*/ 0);
+  // Discover the router-assigned packet ID for this output branch
+  uint32_t id = getPacketid(out_pkt, /*index*/ 0);
 
-    // Emit the packet header (ID + type). This is the metadata getPacketid() observes downstream.
-    writeHeader(out_pkt, PKT_TYPE, id);
+  // Emit the packet header (ID + type). This is the metadata getPacketid() observes downstream.
+  writeHeader(out_pkt, PKT_TYPE, id);
 
-    // Stream out LEN float32 samples; mark the last one with TLAST
-    for (unsigned i = 0; i < LEN; ++i) {
-      float    x = readincr(in_stream);
-      int32_t  w = *reinterpret_cast<int32_t*>(&x);    // bit-cast float -> 32-bit word
-      bool     last = (i == LEN - 1);
-      writeincr(out_pkt, w, last);
-    }
+  // Stream out LEN float32 samples; mark the last one with TLAST
+  for (unsigned i = 0; i < LEN; ++i) {
+    float    x = readincr(in_stream);
+    int32_t  w = *reinterpret_cast<int32_t*>(&x);    // bit-cast float -> 32-bit word
+    bool     last = (i == LEN - 1);
+    writeincr(out_pkt, w, last);
   }
 }

--- a/aieml5/pkt_to_stream.cpp
+++ b/aieml5/pkt_to_stream.cpp
@@ -6,27 +6,25 @@
 void pkt_to_stream(input_pktstream *in, output_stream<float> *out) {
   constexpr int frame_elems = EMBED_DENSE0_INPUT_SIZE;
 
-  while (true) {
-    bool tlast = false;
+  bool tlast = false;
 
-    // Each iteration is expected to start with a packet header.
-    // Discard the header word before consuming the payload samples.
-    readincr(in);
+  // Each iteration is expected to start with a packet header.
+  // Discard the header word before consuming the payload samples.
+  readincr(in);
 
-    for (int i = 0; i < frame_elems; ++i) {
+  for (int i = 0; i < frame_elems; ++i) {
+    int32_t raw = readincr(in, tlast);
+    union {
+      int32_t i;
+      float f;
+    } converter{raw};
+    writeincr(out, converter.f);
+  }
+
+  // Ensure the packet ended where expected to avoid desynchronisation.
+  if (!tlast) {
+    do {
       int32_t raw = readincr(in, tlast);
-      union {
-        int32_t i;
-        float f;
-      } converter{raw};
-      writeincr(out, converter.f);
-    }
-
-    // Ensure the packet ended where expected to avoid desynchronisation.
-    if (!tlast) {
-      do {
-        int32_t raw = readincr(in, tlast);
-      } while (!tlast);
-    }
+    } while (!tlast);
   }
 }


### PR DESCRIPTION
## Summary
- stop the packetize and depacketize kernels from looping forever so each graph iteration completes
- load the dense layer weights from the build data directory instead of a machine-specific absolute path

## Testing
- `make sim` *(fails: ../dsp_lib directory is missing in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5bbbd43c88320a1f639f06a64d24d