### PR TITLE
Add cascaded 128x128 dense layer with stream splitting

### DIFF
--- a/aieml5/Makefile
+++ b/aieml5/Makefile
@@ -73,19 +73,19 @@ all: graph
 # --- AIE Graph Compilation ---
 graph: $(GRAPH_LIB)
 
-$(GRAPH_LIB): $(GRAPH_SRC) stream_to_packet.cpp packet_to_stream.cpp graph.h leaky_relu.h leaky_relu.cpp stream_to_packet.h packet_to_stream.h ../common/nn_defs.h ../common/data_paths.h $(AIE_CFG)
+$(GRAPH_LIB): $(GRAPH_SRC) stream_to_packet.cpp packet_to_stream.cpp split_stream.cpp graph.h leaky_relu.h leaky_relu.cpp split_stream.h stream_to_packet.h packet_to_stream.h ../common/nn_defs.h ../common/data_paths.h $(AIE_CFG)
 	@mkdir -p $(WORK_DIR)
 	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
 	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"
 	@if [ ! -d "$(DSPLIB_PATH)" ]; then \
-	        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
-	        echo "!!! ERROR: Directory not found: '$(DSPLIB_PATH)'"; \
-	        echo "!!! Please set the DSPLIB_PATH variable in your Makefile correctly."; \
-	        echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
-	        exit 1; \
+		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		echo "!!! ERROR: Directory not found: '$(DSPLIB_PATH)'"; \
+		echo "!!! Please set the DSPLIB_PATH variable in your Makefile correctly."; \
+		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		exit 1; \
 	fi
 	@set -o pipefail; \
-	$(VPP) $(VPP_FLAGS) $(GRAPH_SRC) stream_to_packet.cpp packet_to_stream.cpp 2>&1 | tee $(WORK_DIR)/vpp_aie.log
+	$(VPP) $(VPP_FLAGS) $(GRAPH_SRC) stream_to_packet.cpp packet_to_stream.cpp split_stream.cpp 2>&1 | tee $(WORK_DIR)/vpp_aie.log
 	@echo "COMPLETE: AIE graph compiled."
 
 # --- Simulation ---

--- a/aieml5/leaky_relu.cpp
+++ b/aieml5/leaky_relu.cpp
@@ -6,16 +6,14 @@
 #include <adf.h>
 #include <aie_api/aie.hpp>
 
-void leaky_relu_kernel(adf::input_buffer<float>& __restrict in,
-                              adf::output_buffer<float>& __restrict out) {
-  constexpr float alpha = 0.1f;
+void leaky_relu_kernel(adf::input_stream<float>* __restrict in,
+                              adf::output_stream<float>* __restrict out) {
+  constexpr float alpha      = 0.1f;
+  constexpr int   frame_size = HIDDEN_SIZE;
 
-  auto inIt  = aie::begin(in);
-  auto outIt = aie::begin(out);
-  const int N = in.size();   // number of float elements in this window
-
-  for (int i = 0; i < N; ++i) {
-    float x = *inIt++;
-    *outIt++ = (x >= 0.0f) ? x : (alpha * x);
+  for (int i = 0; i < frame_size; ++i) {
+    float x = readincr(in);
+    float y = (x >= 0.0f) ? x : (alpha * x);
+    writeincr(out, y);
   }
 }

--- a/aieml5/leaky_relu.h
+++ b/aieml5/leaky_relu.h
@@ -3,5 +3,5 @@
 #include "nn_defs.h"
 using namespace adf;
 
-void leaky_relu_kernel(adf::input_buffer<float>& __restrict in,
-                        adf::output_buffer<float>& __restrict out) ;
+void leaky_relu_kernel(adf::input_stream<float>* __restrict in,
+                       adf::output_stream<float>* __restrict out);

--- a/aieml5/split_stream.cpp
+++ b/aieml5/split_stream.cpp
@@ -1,0 +1,18 @@
+#include "split_stream.h"
+
+void split_stream_kernel(adf::input_stream<float>* __restrict in,
+                         adf::output_stream<float>* __restrict out0,
+                         adf::output_stream<float>* __restrict out1) {
+  constexpr int total_elems   = HIDDEN_SIZE;
+  constexpr int casc_length   = CASCADE_LENGTH;
+  constexpr int elems_per_out = total_elems / casc_length;
+
+  static_assert(casc_length == 2, "split_stream_kernel currently supports two cascade stages.");
+
+  for (int i = 0; i < elems_per_out; ++i) {
+    writeincr(out0, readincr(in));
+  }
+  for (int i = 0; i < elems_per_out; ++i) {
+    writeincr(out1, readincr(in));
+  }
+}

--- a/aieml5/split_stream.h
+++ b/aieml5/split_stream.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+
+void split_stream_kernel(adf::input_stream<float>* __restrict in,
+                         adf::output_stream<float>* __restrict out0,
+                         adf::output_stream<float>* __restrict out1);


### PR DESCRIPTION
## Summary
- introduce a cascaded 128x128 dense layer that streams weights via RTP and consumes split vector streams
- add a stream-based leaky ReLU followed by a dedicated splitter kernel to distribute activations to each cascade stage
- update the host graph loader and build rules to fetch both dense layers' weights and compile the new kernel sources

## Testing
- make graph *(fails: v++ command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cb79c2388320a34df80d47611a6b