### PR TITLE
Fix packet TLAST handling and update cascade length

### DIFF
--- a/aieml5/hidden_stream_to_packet.cpp
+++ b/aieml5/hidden_stream_to_packet.cpp
@@ -30,10 +30,9 @@ void hidden_stream_to_packet_kernel(input_stream<float>* in_stream,
         int32_t i;
       } converter{value};
 
-      // Only the final word of the final packet asserts TLAST so the downstream
-      // pktsplitter and consumers know the frame has completed.
-      const bool is_last = (branch == branch_count - 1) &&
-                           (i == samples_per_part - 1);
+      // Assert TLAST on the final word of every packet so that the downstream
+      // splitter exposes a complete packet to each cascade branch.
+      const bool is_last = (i == samples_per_part - 1);
       writeincr(out_pkt, converter.i, is_last);
     }
   }

--- a/aieml5/leaky_relu.cpp
+++ b/aieml5/leaky_relu.cpp
@@ -1,19 +1,17 @@
 #include "leaky_relu.h"
+
 #include <aie_api/aie.hpp>
 
-// leaky_relu.h
-#pragma once
-#include <adf.h>
-#include <aie_api/aie.hpp>
+using namespace adf;
 
-void leaky_relu_kernel(adf::input_stream<float>* __restrict in,
-                              adf::output_stream<float>* __restrict out) {
+void leaky_relu_kernel(input_stream<float>* __restrict in,
+                       output_stream<float>* __restrict out) {
   constexpr float alpha      = 0.1f;
   constexpr int   frame_size = HIDDEN_SIZE;
 
   for (int i = 0; i < frame_size; ++i) {
-    float x = readincr(in);
-    float y = (x >= 0.0f) ? x : (alpha * x);
+    const float x = readincr(in);
+    const float y = (x >= 0.0f) ? x : (alpha * x);
     writeincr(out, y);
   }
 }

--- a/aieml5/leaky_relu.h
+++ b/aieml5/leaky_relu.h
@@ -3,5 +3,6 @@
 #include "nn_defs.h"
 using namespace adf;
 
-void leaky_relu_kernel(adf::input_stream<float>* __restrict in,
-                       adf::output_stream<float>* __restrict out);
+void leaky_relu_kernel(input_stream<float>* __restrict in,
+                       output_stream<float>* __restrict out);
+

--- a/aieml5/packet_to_stream.cpp
+++ b/aieml5/packet_to_stream.cpp
@@ -12,8 +12,10 @@ namespace {
  * kernel, forwards @p frame_elems payload samples, and drains any unexpected
  * residual data until TLAST is observed to keep the interface aligned.
  */
-inline void packet_payload_to_stream(adf::input_pktstream* in,
-                                     adf::output_stream<float>* out,
+using namespace adf;
+
+inline void packet_payload_to_stream(input_pktstream* in,
+                                     output_stream<float>* out,
                                      int frame_elems) {
   bool tlast = false;
 
@@ -42,11 +44,11 @@ inline void packet_payload_to_stream(adf::input_pktstream* in,
 
 }  // namespace
 
-void packet_to_stream_kernel(adf::input_pktstream* in, adf::output_stream<float>* out) {
+void packet_to_stream_kernel(input_pktstream* in, output_stream<float>* out) {
   packet_payload_to_stream(in, out, EMBED_DENSE0_INPUT_SIZE);
 }
 
-void packet_to_stream_hidden_kernel(adf::input_pktstream* in,
-                                    adf::output_stream<float>* out) {
+void packet_to_stream_hidden_kernel(input_pktstream* in,
+                                    output_stream<float>* out) {
   packet_payload_to_stream(in, out, HIDDEN_SIZE / CASCADE_LENGTH);
 }

--- a/aieml5/packet_to_stream.h
+++ b/aieml5/packet_to_stream.h
@@ -4,5 +4,5 @@
 
 #include "nn_defs.h"
 
-void packet_to_stream_kernel(adf::input_pktstream* in, adf::output_stream<float>* out);
-void packet_to_stream_hidden_kernel(adf::input_pktstream* in, adf::output_stream<float>* out);
+void packet_to_stream_kernel(input_pktstream* in, output_stream<float>* out);
+void packet_to_stream_hidden_kernel(input_pktstream* in, output_stream<float>* out);

--- a/common/nn_defs.h
+++ b/common/nn_defs.h
@@ -4,7 +4,7 @@ constexpr int INPUT_SIZE = 8;
 constexpr int HIDDEN_SIZE = 128;
 constexpr int OUTPUT_SIZE = 128;
 constexpr float LEAKY_SLOPE = 0.1f;
-constexpr int CASCADE_LENGTH = 2;
+constexpr int CASCADE_LENGTH = 4;
 constexpr int ROLL_CONC_SUBSET_SIZE = 6;
 
 


### PR DESCRIPTION
## Summary
- assert TLAST at the end of every hidden-layer packet so each cascade lane sees a packet boundary
- align stream helper prototypes with current ADF headers and simplify the leaky ReLU kernel
- raise `CASCADE_LENGTH` to 4 to satisfy the DSPLib streaming bandwidth limit

## Testing
- make graph *(fails: `v++` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5de98afd8832089aeadf0f1eac286