### PR TITLE
Add bias add kernel between dense and activation

### DIFF
--- a/aieml5/Makefile
+++ b/aieml5/Makefile
@@ -40,6 +40,7 @@ KERNEL_SRCS   := $(addprefix $(KERNEL_DIR)/, \
         stream_to_packet.cpp \
         hidden_stream_to_packet.cpp \
         packet_to_stream.cpp \
+        bias_add.cpp \
         leaky_relu.cpp \
         roll_concat.cpp)
 KERNEL_HDRS   := $(KERNEL_SRCS:.cpp=.h)

--- a/aieml5/graph.cpp
+++ b/aieml5/graph.cpp
@@ -44,6 +44,14 @@ int main() {
     g.update(g.matrixA_dense0_rtp, dense0Weights.data(), EMBED_DENSE0_WEIGHTS_SIZE);
   }
 
+  {
+    const auto dense0Bias = loadWeights(basePath + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE);
+    if (dense0Bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense0_rtp, dense0Bias.data(), EMBED_DENSE0_BIAS_SIZE);
+  }
+
   for (int cascIdx = 0; cascIdx < CASCADE_LENGTH; ++cascIdx) {
     const std::string weightPath = basePath + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
     const auto dense1Weights = loadWeights(weightPath, EMBED_DENSE1_WEIGHTS_PART_SIZE);

--- a/aieml5/graph.h
+++ b/aieml5/graph.h
@@ -8,6 +8,7 @@
 #include "aie_api/aie_adf.hpp"
 #include "kernels/stream_to_packet.h"
 #include "kernels/packet_to_stream.h"
+#include "kernels/bias_add.h"
 #include "kernels/leaky_relu.h"
 #include "kernels/hidden_stream_to_packet.h"
 #include "kernels/roll_concat.h"
@@ -70,9 +71,11 @@ public:
     dense128x128 dense2;
     input_port matrixA_dense0_rtp;
     input_port matrixA_dense1_rtp[CASCADE_LENGTH];
+    input_port bias_dense0_rtp;
 
     kernel      k_stream_to_packet;
     kernel      k_packet_to_stream;
+    kernel      k_bias_add;
     kernel      k_lrelu0;
     kernel      k_hidden_stream_to_packet;
     kernel      k_roll_concat;
@@ -96,6 +99,11 @@ public:
         source(k_packet_to_stream) = "kernels/packet_to_stream.cpp";
         headers(k_packet_to_stream) = {"kernels/packet_to_stream.h"};
         runtime<ratio>(k_packet_to_stream) = 1.0;
+
+        k_bias_add = kernel::create(bias_add_kernel);
+        source(k_bias_add) = "kernels/bias_add.cpp";
+        headers(k_bias_add) = {"kernels/bias_add.h"};
+        runtime<ratio>(k_bias_add) = 1.0;
 
         k_lrelu0 = kernel::create(leaky_relu_kernel);
         source(k_lrelu0) = "kernels/leaky_relu.cpp";
@@ -129,6 +137,7 @@ public:
         for (int i = 0; i < CASCADE_LENGTH; ++i) {
             adf::connect<adf::parameter>(matrixA_dense1_rtp[i], dense2.matrixA[i]);
         }
+        adf::connect<adf::parameter>(bias_dense0_rtp, async(k_bias_add.in[1]));
 
         // ADF packet switching data flow:
         // input_data -> k_stream_to_packet -> splitter -> k_packet_to_stream -> dense1 -> output_data
@@ -137,7 +146,8 @@ public:
         connect<pktstream>(splitter.out[0], k_packet_to_stream.in[0]);          // splitter → packet_to_stream
         connect<stream>(k_packet_to_stream.out[0], dense1.inB[0]);              // float stream → dense
 
-        connect<stream>(dense1.out[0], k_lrelu0.in[0]);
+        connect<stream>(dense1.out[0], k_bias_add.in[0]);
+        connect<stream>(k_bias_add.out[0], k_lrelu0.in[0]);
         connect<stream>(k_lrelu0.out[0], k_hidden_stream_to_packet.in[0]);
         connect<pktstream>(k_hidden_stream_to_packet.out[0], layer_splitter.in[0]);
 

--- a/aieml5/kernels/bias_add.cpp
+++ b/aieml5/kernels/bias_add.cpp
@@ -2,17 +2,16 @@
 #include "nn_defs.h"
 
 void bias_add_kernel(input_stream<float>* restrict dense_output,
-                     input_stream<float>* restrict bias_stream,
+                     const float* bias_values,
                      output_stream<float>* restrict biased_output)
 {
-    v16float bias_vec = aie::zeros<float, 16>();
-    v16float dense_vec = aie::zeros<float, 16>();
+    v16float dense_vec  = aie::zeros<float, 16>();
+    v16float bias_vec   = aie::zeros<float, 16>();
     v16float result_vec = aie::zeros<float, 16>();
 
-    // Process HIDDEN_SIZE (128) elements in chunks of 16
     for (int i = 0; i < HIDDEN_SIZE; i += 16) {
         dense_vec = readincr_v16(dense_output);
-        bias_vec = readincr_v16(bias_stream);
+        bias_vec  = aie::load_v<16>(bias_values + i);
 
         result_vec = aie::add(dense_vec, bias_vec);
 

--- a/aieml5/kernels/bias_add.h
+++ b/aieml5/kernels/bias_add.h
@@ -6,5 +6,5 @@
 using namespace aie;
 
 void bias_add_kernel(input_stream<float>* restrict dense_output,
-                     input_stream<float>* restrict bias_stream,
+                     const float* bias_values,
                      output_stream<float>* restrict biased_output);


### PR DESCRIPTION
## Summary
- insert a bias_add kernel between dense8x128 and leaky_relu to apply runtime-loaded bias values
- preload the dense layer bias from embed_dense_0_bias.txt via a new RTP port
- include the bias_add kernel sources in the AI Engine build configuration

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e6285cf08320bbc3d5f5c9f343ac