### PR TITLE
Fix bias add kernel integration

### DIFF
--- a/aieml5/Makefile
+++ b/aieml5/Makefile
@@ -41,7 +41,8 @@ KERNEL_SRCS   := $(addprefix $(KERNEL_DIR)/, \
         hidden_stream_to_packet.cpp \
         packet_to_stream.cpp \
         leaky_relu.cpp \
-        roll_concat.cpp)
+        roll_concat.cpp \
+        bias_add.cpp)
 KERNEL_HDRS   := $(KERNEL_SRCS:.cpp=.h)
 
 

--- a/aieml5/graph.cpp
+++ b/aieml5/graph.cpp
@@ -41,7 +41,9 @@ int main() {
     if (dense0Weights.empty()) {
       return -1;
     }
-    g.update(g.matrixA_dense0_rtp, dense0Weights.data(), EMBED_DENSE0_WEIGHTS_SIZE);
+    g.update(g.matrixA_dense0_rtp,
+             dense0Weights.data(),
+             EMBED_DENSE0_WEIGHTS_SIZE * sizeof(float));
   }
 
   {
@@ -49,7 +51,9 @@ int main() {
     if (bias.empty()) {
       return -1;
     }
-    g.update(g.bias_dense0_rtp, bias.data(), EMBED_DENSE0_BIAS_SIZE);
+    g.update(g.bias_dense0_rtp,
+             bias.data(),
+             EMBED_DENSE0_BIAS_SIZE * sizeof(float));
   }
 
   for (int cascIdx = 0; cascIdx < CASCADE_LENGTH; ++cascIdx) {
@@ -58,7 +62,9 @@ int main() {
     if (dense1Weights.empty()) {
       return -1;
     }
-    g.update(g.matrixA_dense1_rtp[cascIdx], dense1Weights.data(), EMBED_DENSE1_WEIGHTS_PART_SIZE);
+    g.update(g.matrixA_dense1_rtp[cascIdx],
+             dense1Weights.data(),
+             EMBED_DENSE1_WEIGHTS_PART_SIZE * sizeof(float));
   }
 
   g.run(1);


### PR DESCRIPTION
## Summary
- include the new bias add kernel in the aieml5 build so it is compiled with the rest of the graph
- fix the runtime parameter updates to send the full byte count for weights and bias payloads

## Testing
- Not run (Vitis toolchain not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68daba136a8883209b240b5e61f7af47