### PR TITLE
Refactor aieml7 graph to packetise ingress stream

### DIFF
--- a/aieml7/Makefile
+++ b/aieml7/Makefile
@@ -42,7 +42,9 @@ KERNEL_SRCS   := \
         window_split_512_to_256x2.cpp \
         window_split_256_to_128x2.cpp \
         roll_concat.cpp \
-        bias_add.cpp
+        bias_add.cpp \
+        stream_to_packet.cpp \
+        packet_to_window.cpp
 KERNEL_HDRS   := $(KERNEL_SRCS:.cpp=.h)
 
 

--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <adf.h>
+#include <array>
+
 #include "nn_defs.h"
 #include "data_paths.h"
 #include "matrix_vector_mul_graph.hpp"
@@ -11,6 +13,8 @@
 #include "window_split_256_to_128x2.h"
 #include "roll_concat.h"
 #include "bias_add.h"
+#include "stream_to_packet.h"
+#include "packet_to_window.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;
@@ -49,7 +53,7 @@ using dense768x128 = matrix_vector_mul_graph<
 // Graph connects dense1 and dense2; leaky ReLU is handled in PL
 class NeuralNetworkGraph : public graph {
 public:
-    input_plio  layer0_in[TP_CASC_LEN_LAYER3];
+    input_plio  layer0_in;
 
     dense768x128 dense3;
     // Final dense layer output directly drives a PLIO
@@ -59,17 +63,38 @@ public:
 
     input_port matrixA_dense2_rtp[TP_CASC_LEN_LAYER3];
 
+    kernel k_stream_to_packet;
+    std::array<kernel, TP_CASC_LEN_LAYER3> k_packet_to_window;
+    pktsplit<TP_CASC_LEN_LAYER3> splitter;
 
 
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
         layer1_out = output_plio::create("layer1_out", plio_32_bits, (base_path + "/" + EMBED_DENSE1_OUTPUT).c_str());
 
+        layer0_in = input_plio::create("layer0_in", plio_32_bits, (base_path + "/solver_0_input.txt").c_str());
+
+        k_stream_to_packet = kernel::create(stream_to_packet_kernel);
+        source(k_stream_to_packet) = "stream_to_packet.cpp";
+        headers(k_stream_to_packet) = {"stream_to_packet.h"};
+        runtime<ratio>(k_stream_to_packet) = 1.0;
+
+        splitter = pktsplit<TP_CASC_LEN_LAYER3>::create();
+
         for (int i = 0; i < (int)TP_CASC_LEN_LAYER3; ++i) {
-            std::string in_file = base_path + "/" + SUBSOLVER0_INPUT_DATA_PREFIX        + std::to_string(i) + ".txt";
-            layer0_in[i]      = input_plio::create( ("layer0_in_"      + std::to_string(i)).c_str(), plio_32_bits, in_file.c_str() );
-            connect<>(layer0_in[i].out[0], dense3.inB[i]);
-          }
+            k_packet_to_window[i] = kernel::create(packet_to_window_kernel);
+            source(k_packet_to_window[i]) = "packet_to_window.cpp";
+            headers(k_packet_to_window[i]) = {"packet_to_window.h"};
+            runtime<ratio>(k_packet_to_window[i]) = 1.0;
+        }
+
+        connect<stream>(layer0_in.out[0], k_stream_to_packet.in[0]);
+        connect<pktstream>(k_stream_to_packet.out[0], splitter.in[0]);
+
+        for (int i = 0; i < (int)TP_CASC_LEN_LAYER3; ++i) {
+            connect<pktstream>(splitter.out[i], k_packet_to_window[i].in[0]);
+            connect<window<4 * SUBSOLVER0_INPUT_PART_SIZE>>(k_packet_to_window[i].out[0], dense3.inB[i]);
+        }
 
 
 

--- a/aieml7/packet_to_window.cpp
+++ b/aieml7/packet_to_window.cpp
@@ -1,0 +1,31 @@
+#include "packet_to_window.h"
+
+#include "nn_defs.h"
+
+#include <cstdint>
+
+using namespace adf;
+
+void packet_to_window_kernel(input_pktstream* in_pkt,
+                             output_window<float>* out_window) {
+  bool tlast = false;
+
+  // Discard the header emitted by the upstream packetiser.
+  (void)readincr(in_pkt);
+
+  for (int i = 0; i < SUBSOLVER0_INPUT_PART_SIZE; ++i) {
+    const int32_t payload = readincr(in_pkt, tlast);
+    union {
+      int32_t i;
+      float f;
+    } converter{payload};
+
+    window_writeincr(out_window, converter.f);
+  }
+
+  if (!tlast) {
+    do {
+      (void)readincr(in_pkt, tlast);
+    } while (!tlast);
+  }
+}

--- a/aieml7/packet_to_window.h
+++ b/aieml7/packet_to_window.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <adf.h>
+
+using namespace adf;
+
+// Converts a packet payload into a window containing SUBSOLVER0_INPUT_PART_SIZE
+// float samples expected by the dense layer cascade leg.
+void packet_to_window_kernel(input_pktstream* in_pkt,
+                             output_window<float>* out_window);

--- a/aieml7/stream_to_packet.cpp
+++ b/aieml7/stream_to_packet.cpp
@@ -1,0 +1,29 @@
+#include "stream_to_packet.h"
+
+#include "nn_defs.h"
+
+#include <cstdint>
+
+using namespace adf;
+
+namespace {
+constexpr unsigned kPacketType = 0;
+}
+
+void stream_to_packet_kernel(input_stream<float>* in_stream,
+                             output_pktstream* out_pkt) {
+  const uint32_t pkt_id = getPacketid(out_pkt, /*index=*/0);
+  writeHeader(out_pkt, kPacketType, pkt_id);
+
+  for (int i = 0; i < SUBSOLVER0_INPUT_SIZE; ++i) {
+    const float sample = readincr(in_stream);
+    const bool is_last = (i == SUBSOLVER0_INPUT_SIZE - 1);
+
+    union {
+      float f;
+      int32_t i;
+    } converter{sample};
+
+    writeincr(out_pkt, converter.i, is_last);
+  }
+}

--- a/aieml7/stream_to_packet.h
+++ b/aieml7/stream_to_packet.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <adf.h>
+
+using namespace adf;
+
+// Packetises one frame of SUBSOLVER0_INPUT_SIZE float samples into a single
+// packet on the ADF packet stream network.
+void stream_to_packet_kernel(input_stream<float>* in_stream,
+                             output_pktstream* out_pkt);


### PR DESCRIPTION
## Summary
- collapse the aieml7 graph input to a single PLIO that packetises the ingress stream
- add packet fan-out kernels that rebuild the window payload for each dense cascade leg
- register the new helper kernels with the aieml7 build so they compile with the graph

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc2a7fa014832080cc041fce7194ac