### PR TITLE
Fix packet window offsets and inline kernel selector

### DIFF
--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -82,7 +82,7 @@ public:
         splitter = pktsplit<TP_CASC_LEN_LAYER3>::create();
 
         for (int i = 0; i < (int)TP_CASC_LEN_LAYER3; ++i) {
-            k_packet_to_window[i] = kernel::create(packet_to_window_kernel);
+            k_packet_to_window[i] = kernel::create(select_packet_to_window_kernel(i));
             source(k_packet_to_window[i]) = "packet_to_window.cpp";
             headers(k_packet_to_window[i]) = {"packet_to_window.h"};
             runtime<ratio>(k_packet_to_window[i]) = 1.0;

--- a/aieml7/packet_to_window.cpp
+++ b/aieml7/packet_to_window.cpp
@@ -6,13 +6,22 @@
 
 using namespace adf;
 
-void packet_to_window_kernel(input_pktstream* in_pkt,
-                             output_window<float>* out_window) {
+namespace {
+
+template <int OffsetWords>
+void packet_to_window_kernel_impl(input_pktstream* in_pkt,
+                                  output_window<float>* out_window) {
   bool tlast = false;
 
   // Discard the header emitted by the upstream packetiser.
   (void)readincr(in_pkt);
 
+  // Skip the samples that belong to previous cascade legs.
+  for (int i = 0; i < OffsetWords; ++i) {
+    (void)readincr(in_pkt, tlast);
+  }
+
+  // Emit the portion of the payload assigned to this cascade leg.
   for (int i = 0; i < SUBSOLVER0_INPUT_PART_SIZE; ++i) {
     const int32_t payload = readincr(in_pkt, tlast);
     union {
@@ -23,9 +32,72 @@ void packet_to_window_kernel(input_pktstream* in_pkt,
     window_writeincr(out_window, converter.f);
   }
 
+  // Drain any remaining packet payload.
   if (!tlast) {
     do {
       (void)readincr(in_pkt, tlast);
     } while (!tlast);
   }
+}
+
+}  // namespace
+
+void packet_to_window_kernel_0(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<0>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_1(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<1 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_2(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<2 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_3(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<3 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_4(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<4 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_5(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<5 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_6(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<6 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_7(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<7 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_8(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<8 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_9(input_pktstream* in_pkt,
+                               output_window<float>* out_window) {
+  packet_to_window_kernel_impl<9 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_10(input_pktstream* in_pkt,
+                                output_window<float>* out_window) {
+  packet_to_window_kernel_impl<10 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
+}
+
+void packet_to_window_kernel_11(input_pktstream* in_pkt,
+                                output_window<float>* out_window) {
+  packet_to_window_kernel_impl<11 * SUBSOLVER0_INPUT_PART_SIZE>(in_pkt, out_window);
 }

--- a/aieml7/packet_to_window.h
+++ b/aieml7/packet_to_window.h
@@ -4,7 +4,56 @@
 
 using namespace adf;
 
+// Signature shared by all packet-to-window kernel entry points.
+using PacketToWindowKernelFn =
+    void (*)(input_pktstream* in_pkt, output_window<float>* out_window);
+
 // Converts a packet payload into a window containing SUBSOLVER0_INPUT_PART_SIZE
-// float samples expected by the dense layer cascade leg.
-void packet_to_window_kernel(input_pktstream* in_pkt,
-                             output_window<float>* out_window);
+// float samples expected by the dense layer cascade leg.  Multiple entry points
+// are generated so that each cascade leg can skip a different portion of the
+// payload before producing its window.
+void packet_to_window_kernel_0(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_1(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_2(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_3(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_4(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_5(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_6(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_7(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_8(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_9(input_pktstream* in_pkt,
+                               output_window<float>* out_window);
+void packet_to_window_kernel_10(input_pktstream* in_pkt,
+                                output_window<float>* out_window);
+void packet_to_window_kernel_11(input_pktstream* in_pkt,
+                                output_window<float>* out_window);
+
+// Returns the packet-to-window kernel associated with the specified cascade
+// index.  Marked inline so that both host and AI Engine compilation units can
+// reference the selector without requiring a separate definition.
+inline PacketToWindowKernelFn select_packet_to_window_kernel(unsigned index) {
+  switch (index) {
+    case 0:  return packet_to_window_kernel_0;
+    case 1:  return packet_to_window_kernel_1;
+    case 2:  return packet_to_window_kernel_2;
+    case 3:  return packet_to_window_kernel_3;
+    case 4:  return packet_to_window_kernel_4;
+    case 5:  return packet_to_window_kernel_5;
+    case 6:  return packet_to_window_kernel_6;
+    case 7:  return packet_to_window_kernel_7;
+    case 8:  return packet_to_window_kernel_8;
+    case 9:  return packet_to_window_kernel_9;
+    case 10: return packet_to_window_kernel_10;
+    case 11: return packet_to_window_kernel_11;
+    default: return nullptr;
+  }
+}


### PR DESCRIPTION
## Summary
- add per-cascade packet-to-window kernel entry points that skip the appropriate payload offsets before emitting their windows
- expose an inline selector so both host and AI Engine builds can choose the correct kernel variant
- update the neural network graph to create packet-to-window kernels via the selector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3cb32c648320b176d28481dd2495