### PR TITLE
Use IO buffers for roll concat kernel

### DIFF
--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -85,11 +85,12 @@ public:
         headers(k_rollconcat0) = {"roll_concat.h"};
         runtime<ratio>(k_rollconcat0) = 1.0;
 
-        connect< window<512> >(layer0_in.out[0], k_rollconcat0.in[0]);
+        connect(layer0_in.out[0], k_rollconcat0.in[0]);
+        dimensions(k_rollconcat0.in[0]) = {HIDDEN_SIZE};
         dimensions(k_rollconcat0.out[0]) = {ROLL_CONCAT_TOTAL};
 
         roll_concat_buffer = adf::shared_buffer<float>::create({ROLL_CONCAT_TOTAL}, 1, TP_CASC_LEN_LAYER3);
-        connect<window<ROLL_CONCAT_TOTAL>>(k_rollconcat0.out[0], roll_concat_buffer.in[0]);
+        connect(k_rollconcat0.out[0], roll_concat_buffer.in[0]);
         write_access(roll_concat_buffer.in[0]) = adf::tiling({
             .buffer_dimension = {ROLL_CONCAT_TOTAL},
             .tiling_dimension = {ROLL_CONCAT_TOTAL},

--- a/aieml7/roll_concat.cpp
+++ b/aieml7/roll_concat.cpp
@@ -3,22 +3,24 @@
 
 using namespace adf;
 
-void roll_concat_kernel(input_window<float>* __restrict in,
-                        output_window<float>* __restrict out) {
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out) {
   constexpr int N = HIDDEN_SIZE;
   constexpr int K = ROLL_CONC_SUBSET_SIZE;
 
   // Read one input window (N floats) into a local buffer
   float buf[N];
+  auto inIt = aie::begin(in);
   for (int i = 0; i < N; ++i) {
-    buf[i] = window_readincr(in);
+    buf[i] = *inIt++;
   }
 
-  // Write K rolled views back-to-back as a single output window of size N*K
+  // Write K rolled views back-to-back as a single output buffer of size N*K
+  auto outIt = aie::begin(out);
   for (int shift = 0; shift < K; ++shift) {
     for (int i = 0; i < N; ++i) {
       const int idx = (i + shift) % N;
-      window_writeincr(out, buf[idx]);
+      *outIt++ = buf[idx];
     }
   }
 }

--- a/aieml7/roll_concat.h
+++ b/aieml7/roll_concat.h
@@ -4,7 +4,7 @@
 
 using namespace adf;
 
-// Reads one window of HIDDEN_SIZE floats and emits
-// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one window).
-void roll_concat_kernel(input_window<float>* __restrict in,
-                        output_window<float>* __restrict out);
+// Reads one buffer of HIDDEN_SIZE floats and emits
+// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one buffer).
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out);


### PR DESCRIPTION
## Summary
- update the roll concat kernel to use input/output buffers instead of deprecated window ports
- adjust graph connections and dimension metadata so the shared buffer receives the correct tiling information

## Testing
- not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc88645e008320bb6b83bf4ece8868