### PR TITLE
Fix shared buffer connections in aieml7 graph

### DIFF
--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -91,7 +91,7 @@ public:
 
         roll_concat_buffer = shared_buffer<float>::create({ROLL_CONCAT_TOTAL}, 1, TP_CASC_LEN_LAYER3);
 
-        connect<window<ROLL_CONCAT_TOTAL * sizeof(float)>>(k_rollconcat0.out[0], roll_concat_buffer.in[0]);
+        connect<>(k_rollconcat0.out[0], roll_concat_buffer.in[0]);
 
         write_access(roll_concat_buffer.in[0]) = tiling({
             .buffer_dimension = {ROLL_CONCAT_TOTAL},
@@ -105,7 +105,7 @@ public:
         }
 
         for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
-            connect<window<ROLL_CONCAT_TILE_SPAN * sizeof(float)>>(roll_concat_buffer.out[i], dense3.inB[i]);
+            connect<>(roll_concat_buffer.out[i], dense3.inB[i]);
             read_access(roll_concat_buffer.out[i]) = tiling({
                 .buffer_dimension = {ROLL_CONCAT_TOTAL},
                 .tiling_dimension = {ROLL_CONCAT_TILE_SPAN},


### PR DESCRIPTION
## Summary
- update the shared buffer connections in the aieml7 graph to use the buffer interface instead of windows
- ensure the roll concat output is linked to the dense layer inputs using shared buffer ports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc8bd462748320ac248b6b18bd5527