### PR TITLE
Add bias add stage before second leaky ReLU

### DIFF
--- a/aieml6/graph.cpp
+++ b/aieml6/graph.cpp
@@ -70,6 +70,17 @@ int main() {
              EMBED_DENSE1_WEIGHTS_PART_SIZE);
   }
 
+  // Load and update dense1 bias
+  {
+    const auto bias = loadWeights(basePath + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense1_rtp,
+             bias.data(),
+             EMBED_DENSE1_BIAS_SIZE);
+  }
+
 
   g.run(1);
   g.wait();


### PR DESCRIPTION
## Summary
- add a second bias add kernel to the embed graph and route the second dense layer through it before activation
- expose a new RTP port for the second dense layer bias and load the associated bias data at runtime

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9a125bbc8320850572bb88a2da58