### PR TITLE
Add missing dense stack to aieml7 graph

### DIFF
--- a/aieml7/graph.cpp
+++ b/aieml7/graph.cpp
@@ -37,16 +37,96 @@ int main() {
   const std::string basePath = std::string(DATA_DIR) + "/";
 
 
-  // Load and update dense2 weights for each cascade leg
+  // Load and update dense0 weights for each cascade leg
   for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER3; ++cascIdx) {
     const std::string weightPath = basePath + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
-    const auto dense2Weights = loadWeights(weightPath, SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+    const auto dense0Weights = loadWeights(weightPath, SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+    if (dense0Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_dense0_rtp[cascIdx],
+             dense0Weights.data(),
+             SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update dense0 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE0_BIAS, SUBSOLVER0_DENSE0_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense0_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE0_BIAS_SIZE);
+  }
+
+  // Load and update dense1 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense1Weights = loadWeights(weightPath, SUBSOLVER0_DENSE1_WEIGHTS_PART_SIZE);
+    if (dense1Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_dense1_rtp[cascIdx],
+             dense1Weights.data(),
+             SUBSOLVER0_DENSE1_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update dense1 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE1_BIAS, SUBSOLVER0_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense1_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE1_BIAS_SIZE);
+  }
+
+  // Load and update dense2 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense2Weights = loadWeights(weightPath, SUBSOLVER0_DENSE2_WEIGHTS_PART_SIZE);
     if (dense2Weights.empty()) {
       return -1;
     }
     g.update(g.matrixA_dense2_rtp[cascIdx],
              dense2Weights.data(),
-             SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+             SUBSOLVER0_DENSE2_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update dense2 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE2_BIAS, SUBSOLVER0_DENSE2_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense2_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE2_BIAS_SIZE);
+  }
+
+  // Load and update dense3 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense3Weights = loadWeights(weightPath, SUBSOLVER0_DENSE3_WEIGHTS_PART_SIZE);
+    if (dense3Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_dense3_rtp[cascIdx],
+             dense3Weights.data(),
+             SUBSOLVER0_DENSE3_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update dense3 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE3_BIAS, SUBSOLVER0_DENSE3_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_dense3_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE3_BIAS_SIZE);
   }
 
   g.run(1);

--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -11,7 +11,6 @@
 #include "window_split_256_to_128x2.h"
 #include "roll_concat.h"
 #include "bias_add.h"
-#include "roll_concat.h"
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;
@@ -53,27 +52,59 @@ using dense768x128 = matrix_vector_mul_graph<
     TP_DUAL_IP,
     TP_NUM_OUTPUTS>;
 
+using dense128x128 = matrix_vector_mul_graph<
+    float, float,
+    OUTPUT_SIZE,
+    HIDDEN_SIZE,
+    TP_SHIFT,
+    TP_RND,
+    TP_NUM_FRAMES,
+    TP_CASC_LEN_LAYER2,
+    TP_SAT,
+    TP_SSR,
+    TP_DIM_A_LEADING,
+    TP_USE_MATRIX_RELOAD,
+    TP_API,
+    TP_DUAL_IP,
+    TP_NUM_OUTPUTS>;
 
-// Graph connects dense1 and dense2; leaky ReLU is handled in PL
+
+// Graph assembles the roll-concat output with a stack of dense, bias and
+// leaky-ReLU layers executed entirely on the AIE graph
 class NeuralNetworkGraph : public graph {
 public:
     input_plio  layer0_in;
-
-    dense768x128 dense3;
-    // Final dense layer output directly drives a PLIO
-    output_plio layer1_out;
+    dense768x128 dense0;
+    dense128x128 dense1;
+    dense128x128 dense2;
+    dense128x128 dense3;
+    output_plio layer_out;
     kernel      k_rollconcat0;
+    kernel      k_biasadd0;
+    kernel      k_biasadd1;
+    kernel      k_biasadd2;
+    kernel      k_biasadd3;
+    kernel      k_lrelu0;
+    kernel      k_lrelu1;
+    kernel      k_lrelu2;
+    kernel      k_lrelu3;
+    kernel      k_wsplit0;
+    kernel      k_wsplit1;
+    kernel      k_wsplit2;
     adf::shared_buffer<float> roll_concat_buffer;
 
-
-
-    input_port matrixA_dense2_rtp[TP_CASC_LEN_LAYER3];
-
-
+    input_port matrixA_dense0_rtp[TP_CASC_LEN_LAYER3];
+    input_port bias_dense0_rtp;
+    input_port matrixA_dense1_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_dense1_rtp;
+    input_port matrixA_dense2_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_dense2_rtp;
+    input_port matrixA_dense3_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_dense3_rtp;
 
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
-        layer1_out = output_plio::create("layer1_out", plio_32_bits, (base_path + "/" + EMBED_DENSE1_OUTPUT).c_str());
+        layer_out = output_plio::create("layer_out", plio_32_bits, (base_path + "/" + SUBSOLVER0_DENSE3_OUTPUT).c_str());
 
         layer0_in      = input_plio::create("layer0_in", plio_32_bits,
             (base_path + "/" + TMP_INP768).c_str());
@@ -101,21 +132,116 @@ public:
 
 
         for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
-            connect<parameter>(matrixA_dense2_rtp[i], dense3.matrixA[i]);
+            connect<parameter>(matrixA_dense0_rtp[i], dense0.matrixA[i]);
         }
 
         for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
-            connect<>(roll_concat_buffer.out[i], dense3.inB[i]);
+            connect<>(roll_concat_buffer.out[i], dense0.inB[i]);
             read_access(roll_concat_buffer.out[i]) = tiling({
                 .buffer_dimension = {ROLL_CONCAT_TOTAL},
                 .tiling_dimension = {ROLL_CONCAT_TILE_SPAN},
                 .offset = {static_cast<int>(i * ROLL_CONCAT_TILE_SPAN)}});
         }
 
-        connect<window<512> >(dense3.out[0], layer1_out.in[0]);
+        k_biasadd0 = kernel::create(bias_add_kernel);
+        source(k_biasadd0) = "bias_add.cpp";
+        headers(k_biasadd0) = {"bias_add.h"};
+        runtime<ratio>(k_biasadd0) = 1.0;
+
+        k_biasadd1 = kernel::create(bias_add_kernel);
+        source(k_biasadd1) = "bias_add.cpp";
+        headers(k_biasadd1) = {"bias_add.h"};
+        runtime<ratio>(k_biasadd1) = 1.0;
+
+        k_biasadd2 = kernel::create(bias_add_kernel);
+        source(k_biasadd2) = "bias_add.cpp";
+        headers(k_biasadd2) = {"bias_add.h"};
+        runtime<ratio>(k_biasadd2) = 1.0;
+
+        k_biasadd3 = kernel::create(bias_add_kernel);
+        source(k_biasadd3) = "bias_add.cpp";
+        headers(k_biasadd3) = {"bias_add.h"};
+        runtime<ratio>(k_biasadd3) = 1.0;
+
+        k_lrelu0 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu0) = "leaky_relu.cpp";
+        headers(k_lrelu0) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu0) = 1.0;
+
+        k_lrelu1 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu1) = "leaky_relu.cpp";
+        headers(k_lrelu1) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu1) = 1.0;
+
+        k_lrelu2 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu2) = "leaky_relu.cpp";
+        headers(k_lrelu2) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu2) = 1.0;
+
+        k_lrelu3 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu3) = "leaky_relu.cpp";
+        headers(k_lrelu3) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu3) = 1.0;
+
+        k_wsplit0 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit0) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit0) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit0) = 1.0;
+
+        k_wsplit1 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit1) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit1) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit1) = 1.0;
+
+        k_wsplit2 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit2) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit2) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit2) = 1.0;
+
+        connect<window<512>>(dense0.out[0], k_biasadd0.in[0]);
+        connect<parameter>(bias_dense0_rtp, k_biasadd0.in[1]);
+        connect<window<512>>(k_biasadd0.out[0], k_lrelu0.in[0]);
+        connect<window<512>>(k_lrelu0.out[0], k_wsplit0.in[0]);
+
+        connect<window<256>>(k_wsplit0.out[0], dense1.inB[0]);
+        connect<window<256>>(k_wsplit0.out[1], dense1.inB[1]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_dense1_rtp[i], dense1.matrixA[i]);
+        }
+
+        connect<window<512>>(dense1.out[0], k_biasadd1.in[0]);
+        connect<parameter>(bias_dense1_rtp, k_biasadd1.in[1]);
+        connect<window<512>>(k_biasadd1.out[0], k_lrelu1.in[0]);
+        connect<window<512>>(k_lrelu1.out[0], k_wsplit1.in[0]);
+
+        connect<window<256>>(k_wsplit1.out[0], dense2.inB[0]);
+        connect<window<256>>(k_wsplit1.out[1], dense2.inB[1]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_dense2_rtp[i], dense2.matrixA[i]);
+        }
+
+        connect<window<512>>(dense2.out[0], k_biasadd2.in[0]);
+        connect<parameter>(bias_dense2_rtp, k_biasadd2.in[1]);
+        connect<window<512>>(k_biasadd2.out[0], k_lrelu2.in[0]);
+        connect<window<512>>(k_lrelu2.out[0], k_wsplit2.in[0]);
+
+        connect<window<256>>(k_wsplit2.out[0], dense3.inB[0]);
+        connect<window<256>>(k_wsplit2.out[1], dense3.inB[1]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_dense3_rtp[i], dense3.matrixA[i]);
+        }
+
+        connect<window<512>>(dense3.out[0], k_biasadd3.in[0]);
+        connect<parameter>(bias_dense3_rtp, k_biasadd3.in[1]);
+        connect<window<512>>(k_biasadd3.out[0], k_lrelu3.in[0]);
+
+        connect<window<512>>(k_lrelu3.out[0], layer_out.in[0]);
 
 
-        
+
         // constexpr unsigned dense2_base_col = 2;
         // constexpr unsigned dense2_row = 0;
         // auto dense2_kernels = dense2.getKernels();


### PR DESCRIPTION
## Summary
- add bias, activation, and window split kernels to aieml7 so the roll-concat output flows through the full dense stack
- load weights and biases for all dense layers when running the aieml7 graph simulation

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc9c8d3eb48320b596e2a84d865ffb