### PR TITLE
Add stitched aieml9 graph

### DIFF
--- a/aieml9/Makefile
+++ b/aieml9/Makefile
@@ -1,0 +1,79 @@
+# ===================================================================
+# Makefile for Vitis AIE Graph Compilation & Simulation
+# ===================================================================
+
+SHELL := /bin/bash
+
+# ==== CONFIG ====
+PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm
+TARGET       ?= hw
+DATA_DIR    ?= ../data
+DATA_DIR := $(abspath $(DATA_DIR))
+VITIS_PATH   ?= /tools/Xilinx/Vitis/2024.2
+DSPLIB_PATH  ?= ../dsp_lib
+
+# ==== PROJECT FILES & DIRECTORIES ====
+GRAPH_SRC     := graph.cpp
+WORK_DIR      := Work
+GRAPH_LIB     := $(WORK_DIR)/libadf.a
+AIE_CFG       := aie.cfg
+KERNEL_SRCS   := \
+        leaky_relu.cpp \
+        window_split_128_to_64x2.cpp \
+        roll_concat.cpp \
+        bias_add.cpp
+KERNEL_HDRS   := $(KERNEL_SRCS:.cpp=.h)
+
+# ==== TOOLS ====
+VPP          := v++
+AIESIM       := aiesimulator
+
+# ==== COMPILER FLAGS ====
+AIE_INCLUDE_FLAGS := \
+        --include="./" \
+        --include="../common" \
+        --include="$(DSPLIB_PATH)/L1/src/aie" \
+        --include="$(DSPLIB_PATH)/L1/include/aie" \
+        --include="$(DSPLIB_PATH)/L2/include/aie"
+
+VPP_FLAGS := \
+        -c \
+        --mode aie \
+        --target=$(TARGET) \
+        --platform=$(PLATFORM) \
+        --work_dir=$(WORK_DIR) \
+        $(AIE_INCLUDE_FLAGS)
+
+.PHONY: all graph sim clean
+
+all: graph
+
+graph: $(GRAPH_LIB)
+
+$(GRAPH_LIB): $(GRAPH_SRC) $(KERNEL_SRCS) $(KERNEL_HDRS) graph.h ../common/nn_defs.h ../common/data_paths.h $(AIE_CFG)
+	@mkdir -p $(WORK_DIR)
+	@echo "--- Compiling AIE Graph for TARGET=$(TARGET) ---"
+	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"
+	@if [ ! -d "$(DSPLIB_PATH)" ]; then \
+		@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		@echo "!!! ERROR: Directory not found: '$(DSPLIB_PATH)'"; \
+		@echo "!!! Please set the DSPLIB_PATH variable in your Makefile correctly."; \
+		@echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		@exit 1; \
+	fi
+	@set -o pipefail; \
+$(VPP) $(VPP_FLAGS) $(GRAPH_SRC) $(KERNEL_SRCS) 2>&1 | tee $(WORK_DIR)/vpp_aie.log
+	@echo "COMPLETE: AIE graph compiled."
+
+sim: graph
+	@echo "--- Starting AI Engine simulation (aiesimulator) ---"
+	DATA_DIR=$(abspath $(DATA_DIR)) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
+	@echo "COMPLETE: AI Engine simulation finished."
+
+clean:
+	@echo "--- Cleaning Workspace ---"
+	rm -rf $(WORK_DIR) .Xil *.log *.csv *.db *.aiecompile_summary \
+	aiesimulator_output build_hw \
+	pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
+	*.json *.vcd
+	@echo "CLEANED: Build and work directories removed."

--- a/aieml9/aie.cfg
+++ b/aieml9/aie.cfg
@@ -1,0 +1,2 @@
+[aie]
+enable-partition=3:33:aieml

--- a/aieml9/bias_add.cpp
+++ b/aieml9/bias_add.cpp
@@ -1,0 +1,14 @@
+#include "bias_add.h"
+
+void bias_add_kernel(input_window<float>* __restrict dense_window,
+                    output_window<float>* __restrict biased_window,
+                    const float (&bias)[HIDDEN_SIZE])
+{
+    // Process one window of HIDDEN_SIZE floats
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
+        float x = window_readincr(dense_window);
+        float y = x + bias[i];
+        window_writeincr(biased_window, y);
+    }
+}
+                     

--- a/aieml9/bias_add.h
+++ b/aieml9/bias_add.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+using namespace adf;
+
+void bias_add_kernel(input_window<float>* __restrict dense_window,
+                     output_window<float>* __restrict biased_window,
+                     const float (&bias)[HIDDEN_SIZE]);

--- a/aieml9/graph.cpp
+++ b/aieml9/graph.cpp
@@ -1,0 +1,192 @@
+#include "graph.h"
+#include "data_paths.h"
+#include "nn_defs.h"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+NeuralNetworkGraph g;
+
+#if defined(__AIESIM__) || defined(__X86SIM__)
+int main() {
+  auto loadWeights = [](const std::string& path, std::size_t expectedCount) -> std::vector<float> {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+      std::cerr << "Error: Could not open weight file '" << path << "'" << std::endl;
+      return {};
+    }
+
+    std::vector<float> weights;
+    weights.reserve(expectedCount);
+    float value = 0.0f;
+    while (file >> value) {
+      weights.push_back(value);
+    }
+
+    if (weights.size() != expectedCount) {
+      std::cerr << "Error: Expected " << expectedCount << " weights from '" << path
+                << "', got " << weights.size() << std::endl;
+      return {};
+    }
+    return weights;
+  };
+
+  g.init();
+
+  const std::string basePath = std::string(DATA_DIR) + "/";
+
+  // Load and update embed dense0 weights
+  {
+    const auto dense0Weights = loadWeights(basePath + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE);
+    if (dense0Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_embed0_rtp,
+             dense0Weights.data(),
+             EMBED_DENSE0_WEIGHTS_SIZE);
+  }
+
+  // Load and update embed dense0 bias
+  {
+    const auto bias = loadWeights(basePath + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_embed0_rtp,
+             bias.data(),
+             EMBED_DENSE0_BIAS_SIZE);
+  }
+
+  // Load and update embed dense1 weights for each cascade
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense1Weights = loadWeights(weightPath, EMBED_DENSE1_WEIGHTS_PART_SIZE);
+    if (dense1Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_embed1_rtp[cascIdx],
+             dense1Weights.data(),
+             EMBED_DENSE1_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update embed dense1 bias
+  {
+    const auto bias = loadWeights(basePath + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_embed1_rtp,
+             bias.data(),
+             EMBED_DENSE1_BIAS_SIZE);
+  }
+
+  // Load and update solver dense0 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER3; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense0Weights = loadWeights(weightPath, SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+    if (dense0Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_solver0_rtp[cascIdx],
+             dense0Weights.data(),
+             SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update solver dense0 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE0_BIAS, SUBSOLVER0_DENSE0_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_solver0_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE0_BIAS_SIZE);
+  }
+
+  // Load and update solver dense1 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE1_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense1Weights = loadWeights(weightPath, SUBSOLVER0_DENSE1_WEIGHTS_PART_SIZE);
+    if (dense1Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_solver1_rtp[cascIdx],
+             dense1Weights.data(),
+             SUBSOLVER0_DENSE1_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update solver dense1 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE1_BIAS, SUBSOLVER0_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_solver1_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE1_BIAS_SIZE);
+  }
+
+  // Load and update solver dense2 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE2_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense2Weights = loadWeights(weightPath, SUBSOLVER0_DENSE2_WEIGHTS_PART_SIZE);
+    if (dense2Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_solver2_rtp[cascIdx],
+             dense2Weights.data(),
+             SUBSOLVER0_DENSE2_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update solver dense2 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE2_BIAS, SUBSOLVER0_DENSE2_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_solver2_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE2_BIAS_SIZE);
+  }
+
+  // Load and update solver dense3 weights for each cascade leg
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_LAYER2; ++cascIdx) {
+    const std::string weightPath = basePath + SUBSOLVER0_DENSE3_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto dense3Weights = loadWeights(weightPath, SUBSOLVER0_DENSE3_WEIGHTS_PART_SIZE);
+    if (dense3Weights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_solver3_rtp[cascIdx],
+             dense3Weights.data(),
+             SUBSOLVER0_DENSE3_WEIGHTS_PART_SIZE);
+  }
+
+  // Load and update solver dense3 bias
+  {
+    const auto bias = loadWeights(basePath + SUBSOLVER0_DENSE3_BIAS, SUBSOLVER0_DENSE3_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.bias_solver3_rtp,
+             bias.data(),
+             SUBSOLVER0_DENSE3_BIAS_SIZE);
+  }
+
+  // Load and update output dense weights
+  {
+    const auto denseWeights = loadWeights(basePath + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE);
+    if (denseWeights.empty()) {
+      return -1;
+    }
+    g.update(g.matrixA_output0_rtp,
+             denseWeights.data(),
+             OUTPUT_DENSE0_WEIGHTS_SIZE);
+  }
+
+  g.run(1);
+  g.wait();
+  g.end();
+  return 0;
+}
+#endif

--- a/aieml9/graph.h
+++ b/aieml9/graph.h
@@ -1,0 +1,329 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+#include "data_paths.h"
+#include "matrix_vector_mul_graph.hpp"
+#include "aie_api/aie_adf.hpp"
+#include "leaky_relu.h"
+#include "window_split_128_to_64x2.h"
+#include "roll_concat.h"
+#include "bias_add.h"
+
+using namespace adf;
+using namespace xf::dsp::aie::blas::matrix_vector_mul;
+
+static constexpr unsigned int TP_SHIFT = 0;
+static constexpr unsigned int TP_RND = rnd_floor;
+static constexpr unsigned int TP_NUM_FRAMES = 1;
+static constexpr unsigned int TP_SAT = 0;
+static constexpr unsigned int TP_SSR = 1;
+static constexpr unsigned int TP_DIM_A_LEADING = 1;
+static constexpr unsigned int TP_USE_MATRIX_RELOAD = 1;
+static constexpr unsigned int TP_API = 0;
+static constexpr unsigned int TP_DUAL_IP = 0;
+static constexpr unsigned int TP_NUM_OUTPUTS = 1;
+static constexpr unsigned int TP_CASC_LEN_LAYER1 = 1;
+static constexpr unsigned int TP_CASC_LEN_LAYER2 = 2;
+static constexpr unsigned int TP_CASC_LEN_LAYER3 = 12;
+
+static_assert((ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE) % TP_CASC_LEN_LAYER3 == 0,
+              "ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE must be divisible by TP_CASC_LEN_LAYER3");
+static constexpr unsigned int ROLL_CONCAT_TOTAL = ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE;
+static constexpr unsigned int ROLL_CONCAT_TILE_SPAN = ROLL_CONCAT_TOTAL / TP_CASC_LEN_LAYER3;
+static_assert(ROLL_CONCAT_TILE_SPAN * TP_CASC_LEN_LAYER3 == ROLL_CONCAT_TOTAL,
+              "Shared buffer tiling must cover the entire roll-concat frame");
+
+using dense8x128 = matrix_vector_mul_graph<
+    float, float,
+    HIDDEN_SIZE,
+    INPUT_SIZE,
+    TP_SHIFT,
+    TP_RND,
+    TP_NUM_FRAMES,
+    TP_CASC_LEN_LAYER1,
+    TP_SAT,
+    TP_SSR,
+    TP_DIM_A_LEADING,
+    TP_USE_MATRIX_RELOAD,
+    TP_API,
+    TP_DUAL_IP,
+    TP_NUM_OUTPUTS>;
+
+using dense128x128 = matrix_vector_mul_graph<
+    float, float,
+    OUTPUT_SIZE,
+    HIDDEN_SIZE,
+    TP_SHIFT,
+    TP_RND,
+    TP_NUM_FRAMES,
+    TP_CASC_LEN_LAYER2,
+    TP_SAT,
+    TP_SSR,
+    TP_DIM_A_LEADING,
+    TP_USE_MATRIX_RELOAD,
+    TP_API,
+    TP_DUAL_IP,
+    TP_NUM_OUTPUTS>;
+
+using dense768x128 = matrix_vector_mul_graph<
+    float, float,
+    128,
+    768,
+    TP_SHIFT,
+    TP_RND,
+    TP_NUM_FRAMES,
+    TP_CASC_LEN_LAYER3,
+    TP_SAT,
+    TP_SSR,
+    TP_DIM_A_LEADING,
+    TP_USE_MATRIX_RELOAD,
+    TP_API,
+    TP_DUAL_IP,
+    TP_NUM_OUTPUTS>;
+
+using dense128x32 = matrix_vector_mul_graph<
+    float, float,
+    32,
+    HIDDEN_SIZE,
+    TP_SHIFT,
+    TP_RND,
+    TP_NUM_FRAMES,
+    TP_CASC_LEN_LAYER1,
+    TP_SAT,
+    TP_SSR,
+    TP_DIM_A_LEADING,
+    TP_USE_MATRIX_RELOAD,
+    TP_API,
+    TP_DUAL_IP,
+    TP_NUM_OUTPUTS>;
+
+class NeuralNetworkGraph : public graph {
+public:
+    input_plio  layer0_in;
+    dense8x128   embed_dense0;
+    dense128x128 embed_dense1;
+    dense768x128 solver_dense0;
+    dense128x128 solver_dense1;
+    dense128x128 solver_dense2;
+    dense128x128 solver_dense3;
+    dense128x32  output_dense0;
+    output_plio layer_out;
+
+    kernel k_bias_embed0;
+    kernel k_bias_embed1;
+    kernel k_bias_solver0;
+    kernel k_bias_solver1;
+    kernel k_bias_solver2;
+    kernel k_bias_solver3;
+
+    kernel k_lrelu_embed0;
+    kernel k_lrelu_embed1;
+    kernel k_lrelu_solver0;
+    kernel k_lrelu_solver1;
+    kernel k_lrelu_solver2;
+    kernel k_lrelu_solver3;
+
+    kernel k_wsplit_embed0;
+    kernel k_wsplit_solver0;
+    kernel k_wsplit_solver1;
+    kernel k_wsplit_solver2;
+
+    kernel k_rollconcat;
+
+    adf::shared_buffer<float> roll_concat_buffer;
+
+    input_port matrixA_embed0_rtp;
+    input_port bias_embed0_rtp;
+    input_port matrixA_embed1_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_embed1_rtp;
+
+    input_port matrixA_solver0_rtp[TP_CASC_LEN_LAYER3];
+    input_port bias_solver0_rtp;
+    input_port matrixA_solver1_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_solver1_rtp;
+    input_port matrixA_solver2_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_solver2_rtp;
+    input_port matrixA_solver3_rtp[TP_CASC_LEN_LAYER2];
+    input_port bias_solver3_rtp;
+
+    input_port matrixA_output0_rtp;
+
+    NeuralNetworkGraph() {
+        std::string base_path = DATA_DIR;
+        layer0_in = input_plio::create("layer0_in", plio_32_bits,
+                                       (base_path + "/" + EMBED_INPUT_DATA).c_str());
+        layer_out = output_plio::create("layer_out", plio_32_bits,
+                                        (base_path + "/" + OUTPUT_DENSE0_OUTPUT).c_str());
+
+        connect<parameter>(matrixA_embed0_rtp, embed_dense0.matrixA[0]);
+        connect<>(layer0_in.out[0], embed_dense0.inB[0]);
+
+        k_bias_embed0 = kernel::create(bias_add_kernel);
+        source(k_bias_embed0) = "bias_add.cpp";
+        headers(k_bias_embed0) = {"bias_add.h"};
+        runtime<ratio>(k_bias_embed0) = 1.0;
+
+        k_bias_embed1 = kernel::create(bias_add_kernel);
+        source(k_bias_embed1) = "bias_add.cpp";
+        headers(k_bias_embed1) = {"bias_add.h"};
+        runtime<ratio>(k_bias_embed1) = 1.0;
+
+        k_bias_solver0 = kernel::create(bias_add_kernel);
+        source(k_bias_solver0) = "bias_add.cpp";
+        headers(k_bias_solver0) = {"bias_add.h"};
+        runtime<ratio>(k_bias_solver0) = 1.0;
+
+        k_bias_solver1 = kernel::create(bias_add_kernel);
+        source(k_bias_solver1) = "bias_add.cpp";
+        headers(k_bias_solver1) = {"bias_add.h"};
+        runtime<ratio>(k_bias_solver1) = 1.0;
+
+        k_bias_solver2 = kernel::create(bias_add_kernel);
+        source(k_bias_solver2) = "bias_add.cpp";
+        headers(k_bias_solver2) = {"bias_add.h"};
+        runtime<ratio>(k_bias_solver2) = 1.0;
+
+        k_bias_solver3 = kernel::create(bias_add_kernel);
+        source(k_bias_solver3) = "bias_add.cpp";
+        headers(k_bias_solver3) = {"bias_add.h"};
+        runtime<ratio>(k_bias_solver3) = 1.0;
+
+        k_lrelu_embed0 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_embed0) = "leaky_relu.cpp";
+        headers(k_lrelu_embed0) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_embed0) = 1.0;
+
+        k_lrelu_embed1 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_embed1) = "leaky_relu.cpp";
+        headers(k_lrelu_embed1) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_embed1) = 1.0;
+
+        k_lrelu_solver0 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_solver0) = "leaky_relu.cpp";
+        headers(k_lrelu_solver0) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_solver0) = 1.0;
+
+        k_lrelu_solver1 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_solver1) = "leaky_relu.cpp";
+        headers(k_lrelu_solver1) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_solver1) = 1.0;
+
+        k_lrelu_solver2 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_solver2) = "leaky_relu.cpp";
+        headers(k_lrelu_solver2) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_solver2) = 1.0;
+
+        k_lrelu_solver3 = kernel::create(leaky_relu_kernel);
+        source(k_lrelu_solver3) = "leaky_relu.cpp";
+        headers(k_lrelu_solver3) = {"leaky_relu.h"};
+        runtime<ratio>(k_lrelu_solver3) = 1.0;
+
+        k_wsplit_embed0 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit_embed0) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit_embed0) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit_embed0) = 1.0;
+
+        k_wsplit_solver0 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit_solver0) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit_solver0) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit_solver0) = 1.0;
+
+        k_wsplit_solver1 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit_solver1) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit_solver1) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit_solver1) = 1.0;
+
+        k_wsplit_solver2 = kernel::create(window_split_128_to_64x2);
+        source(k_wsplit_solver2) = "window_split_128_to_64x2.cpp";
+        headers(k_wsplit_solver2) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(k_wsplit_solver2) = 1.0;
+
+        k_rollconcat = kernel::create(roll_concat_kernel);
+        source(k_rollconcat) = "roll_concat.cpp";
+        headers(k_rollconcat) = {"roll_concat.h"};
+        runtime<ratio>(k_rollconcat) = 1.0;
+
+        connect<window<512>>(embed_dense0.out[0], k_bias_embed0.in[0]);
+        connect<parameter>(bias_embed0_rtp, k_bias_embed0.in[1]);
+        connect<window<512>>(k_bias_embed0.out[0], k_lrelu_embed0.in[0]);
+        connect<window<512>>(k_lrelu_embed0.out[0], k_wsplit_embed0.in[0]);
+
+        connect<window<256>>(k_wsplit_embed0.out[0], embed_dense1.inB[0]);
+        connect<window<256>>(k_wsplit_embed0.out[1], embed_dense1.inB[1]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_embed1_rtp[i], embed_dense1.matrixA[i]);
+        }
+
+        connect<window<512>>(embed_dense1.out[0], k_bias_embed1.in[0]);
+        connect<parameter>(bias_embed1_rtp, k_bias_embed1.in[1]);
+        connect<window<512>>(k_bias_embed1.out[0], k_lrelu_embed1.in[0]);
+        connect<window<512>>(k_lrelu_embed1.out[0], k_rollconcat.in[0]);
+
+        dimensions(k_rollconcat.in[0]) = {HIDDEN_SIZE};
+        dimensions(k_rollconcat.out[0]) = {ROLL_CONCAT_TOTAL};
+
+        roll_concat_buffer = shared_buffer<float>::create({ROLL_CONCAT_TOTAL}, 1, TP_CASC_LEN_LAYER3);
+
+        connect<>(k_rollconcat.out[0], roll_concat_buffer.in[0]);
+        write_access(roll_concat_buffer.in[0]) = tiling({
+            .buffer_dimension = {ROLL_CONCAT_TOTAL},
+            .tiling_dimension = {ROLL_CONCAT_TOTAL},
+            .offset = {0}
+        });
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
+            connect<parameter>(matrixA_solver0_rtp[i], solver_dense0.matrixA[i]);
+        }
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
+            connect<>(roll_concat_buffer.out[i], solver_dense0.inB[i]);
+            read_access(roll_concat_buffer.out[i]) = tiling({
+                .buffer_dimension = {ROLL_CONCAT_TOTAL},
+                .tiling_dimension = {ROLL_CONCAT_TILE_SPAN},
+                .offset = {static_cast<int>(i * ROLL_CONCAT_TILE_SPAN)}
+            });
+        }
+
+        connect<window<512>>(solver_dense0.out[0], k_bias_solver0.in[0]);
+        connect<parameter>(bias_solver0_rtp, k_bias_solver0.in[1]);
+        connect<window<512>>(k_bias_solver0.out[0], k_lrelu_solver0.in[0]);
+        connect<window<512>>(k_lrelu_solver0.out[0], k_wsplit_solver0.in[0]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_solver1_rtp[i], solver_dense1.matrixA[i]);
+        }
+        connect<window<256>>(k_wsplit_solver0.out[0], solver_dense1.inB[0]);
+        connect<window<256>>(k_wsplit_solver0.out[1], solver_dense1.inB[1]);
+
+        connect<window<512>>(solver_dense1.out[0], k_bias_solver1.in[0]);
+        connect<parameter>(bias_solver1_rtp, k_bias_solver1.in[1]);
+        connect<window<512>>(k_bias_solver1.out[0], k_lrelu_solver1.in[0]);
+        connect<window<512>>(k_lrelu_solver1.out[0], k_wsplit_solver1.in[0]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_solver2_rtp[i], solver_dense2.matrixA[i]);
+        }
+        connect<window<256>>(k_wsplit_solver1.out[0], solver_dense2.inB[0]);
+        connect<window<256>>(k_wsplit_solver1.out[1], solver_dense2.inB[1]);
+
+        connect<window<512>>(solver_dense2.out[0], k_bias_solver2.in[0]);
+        connect<parameter>(bias_solver2_rtp, k_bias_solver2.in[1]);
+        connect<window<512>>(k_bias_solver2.out[0], k_lrelu_solver2.in[0]);
+        connect<window<512>>(k_lrelu_solver2.out[0], k_wsplit_solver2.in[0]);
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
+            connect<parameter>(matrixA_solver3_rtp[i], solver_dense3.matrixA[i]);
+        }
+        connect<window<256>>(k_wsplit_solver2.out[0], solver_dense3.inB[0]);
+        connect<window<256>>(k_wsplit_solver2.out[1], solver_dense3.inB[1]);
+
+        connect<window<512>>(solver_dense3.out[0], k_bias_solver3.in[0]);
+        connect<parameter>(bias_solver3_rtp, k_bias_solver3.in[1]);
+        connect<window<512>>(k_bias_solver3.out[0], k_lrelu_solver3.in[0]);
+
+        connect<parameter>(matrixA_output0_rtp, output_dense0.matrixA[0]);
+        connect<window<512>>(k_lrelu_solver3.out[0], output_dense0.inB[0]);
+        connect<window<128>>(output_dense0.out[0], layer_out.in[0]);
+    }
+};

--- a/aieml9/leaky_relu.cpp
+++ b/aieml9/leaky_relu.cpp
@@ -1,0 +1,17 @@
+#include "leaky_relu.h"
+#include <aie_api/aie.hpp>
+
+using namespace adf;
+
+void leaky_relu_kernel(input_window<float>* __restrict in,
+                       output_window<float>* __restrict out) {
+  constexpr float alpha      = 0.1f;
+  constexpr int   frame_size = 128;
+
+  // process one window of HIDDEN_SIZE elements
+  for (int i = 0; i < frame_size; ++i) {
+    float x = window_readincr(in);
+    float y = (x >= 0.0f) ? x : (alpha * x);
+    window_writeincr(out, y);
+  }
+}

--- a/aieml9/leaky_relu.h
+++ b/aieml9/leaky_relu.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+using namespace adf;
+
+// void leaky_relu_kernel(input_stream<float>* __restrict in,
+//                        output_stream<float>* __restrict out);
+
+void leaky_relu_kernel(input_window<float>* __restrict in,
+                        output_window<float>* __restrict out);

--- a/aieml9/roll_concat.cpp
+++ b/aieml9/roll_concat.cpp
@@ -1,0 +1,26 @@
+#include "roll_concat.h"
+#include <aie_api/aie.hpp>
+
+using namespace adf;
+
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out) {
+  constexpr int N = HIDDEN_SIZE;
+  constexpr int K = ROLL_CONC_SUBSET_SIZE;
+
+  // Read one input window (N floats) into a local buffer
+  float buf[N];
+  auto inIt = aie::begin(in);
+  for (int i = 0; i < N; ++i) {
+    buf[i] = *inIt++;
+  }
+
+  // Write K rolled views back-to-back as a single output buffer of size N*K
+  auto outIt = aie::begin(out);
+  for (int shift = 0; shift < K; ++shift) {
+    for (int i = 0; i < N; ++i) {
+      const int idx = (i + shift) % N;
+      *outIt++ = buf[idx];
+    }
+  }
+}

--- a/aieml9/roll_concat.h
+++ b/aieml9/roll_concat.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+
+using namespace adf;
+
+// Reads one buffer of HIDDEN_SIZE floats and emits
+// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one buffer).
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out);

--- a/aieml9/window_split_128_to_64x2.cpp
+++ b/aieml9/window_split_128_to_64x2.cpp
@@ -1,0 +1,16 @@
+#include "window_split_128_to_64x2.h"
+
+void window_split_128_to_64x2(input_window<float>* __restrict in,
+                              output_window<float>* __restrict out0,
+                              output_window<float>* __restrict out1) {
+  constexpr int N  = 128;
+  constexpr int H  = 64;
+
+  // First 64 → out0
+  for (int i = 0; i < H; ++i)
+    window_writeincr(out0, window_readincr(in));
+
+  // Second 64 → out1
+  for (int i = 0; i < H; ++i)
+    window_writeincr(out1, window_readincr(in));
+}

--- a/aieml9/window_split_128_to_64x2.h
+++ b/aieml9/window_split_128_to_64x2.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <adf.h>
+using namespace adf;
+
+void window_split_128_to_64x2(input_window<float>* __restrict in,
+                              output_window<float>* __restrict out0,
+                              output_window<float>* __restrict out1);


### PR DESCRIPTION
## Summary
- add a new aieml9 AI Engine graph that sequentially connects the aieml6 embed, aieml7 solver, and aieml8 output layers into one stitched pipeline
- load weights and biases for every layer of the combined graph and provide a dedicated project Makefile and kernels

## Testing
- make graph *(fails: v++ not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd373d8e4c8320b046900f5b3f6f24