### PR TITLE
Stream concatenated solver weights via shared buffers

### DIFF
--- a/aieml7/bias_add.cpp
+++ b/aieml7/bias_add.cpp
@@ -2,12 +2,13 @@
 
 void bias_add_kernel(input_window<float>* __restrict dense_window,
                     output_window<float>* __restrict biased_window,
-                    const float (&bias)[HIDDEN_SIZE])
+                    input_buffer<float>& __restrict bias_buffer)
 {
-    // Process one window of HIDDEN_SIZE floats
+    float* __restrict bias_ptr = bias_buffer.data();
+
     for (int i = 0; i < HIDDEN_SIZE; ++i) {
-        float x = window_readincr(dense_window);
-        float y = x + bias[i];
+        const float x = window_readincr(dense_window);
+        const float y = x + bias_ptr[i];
         window_writeincr(biased_window, y);
     }
 }

--- a/aieml7/bias_add.h
+++ b/aieml7/bias_add.h
@@ -5,4 +5,4 @@ using namespace adf;
 
 void bias_add_kernel(input_window<float>* __restrict dense_window,
                      output_window<float>* __restrict biased_window,
-                     const float (&bias)[HIDDEN_SIZE]);
+                     input_buffer<float>& __restrict bias_buffer);

--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -35,6 +35,72 @@ static constexpr unsigned int ROLL_CONCAT_TILE_SPAN = ROLL_CONCAT_TOTAL / TP_CAS
 static_assert(ROLL_CONCAT_TILE_SPAN * TP_CASC_LEN_LAYER3 == ROLL_CONCAT_TOTAL,
               "Shared buffer tiling must cover the entire roll-concat frame");
 
+static constexpr unsigned int WEIGHTS_TILE_CAPACITY = 12288;
+static constexpr unsigned int DENSE0_WEIGHT_TILE_SIZE = SUBSOLVER0_DENSE0_WEIGHTS_PART_SIZE;
+static constexpr unsigned int DENSE1_WEIGHT_TILE_SIZE = SUBSOLVER0_DENSE1_WEIGHTS_PART_SIZE;
+static constexpr unsigned int DENSE2_WEIGHT_TILE_SIZE = SUBSOLVER0_DENSE2_WEIGHTS_PART_SIZE;
+static constexpr unsigned int DENSE3_WEIGHT_TILE_SIZE = SUBSOLVER0_DENSE3_WEIGHTS_PART_SIZE;
+
+static_assert(DENSE0_WEIGHT_TILE_SIZE <= WEIGHTS_TILE_CAPACITY,
+              "Dense0 weight tiles must not exceed 12,288 floats");
+static_assert(DENSE1_WEIGHT_TILE_SIZE <= WEIGHTS_TILE_CAPACITY,
+              "Dense1 weight tiles must not exceed 12,288 floats");
+static_assert(DENSE2_WEIGHT_TILE_SIZE <= WEIGHTS_TILE_CAPACITY,
+              "Dense2 weight tiles must not exceed 12,288 floats");
+static_assert(DENSE3_WEIGHT_TILE_SIZE <= WEIGHTS_TILE_CAPACITY,
+              "Dense3 weight tiles must not exceed 12,288 floats");
+
+static constexpr unsigned int DENSE0_WEIGHT_TILE_COUNT = TP_CASC_LEN_LAYER3;
+static constexpr unsigned int DENSE1_WEIGHT_TILE_COUNT = TP_CASC_LEN_LAYER2;
+static constexpr unsigned int DENSE2_WEIGHT_TILE_COUNT = TP_CASC_LEN_LAYER2;
+static constexpr unsigned int DENSE3_WEIGHT_TILE_COUNT = TP_CASC_LEN_LAYER2;
+
+static_assert(SUBSOLVER0_DENSE0_WEIGHTS_SIZE == DENSE0_WEIGHT_TILE_SIZE * DENSE0_WEIGHT_TILE_COUNT,
+              "Dense0 weights must map to uniform tiles");
+static_assert(SUBSOLVER0_DENSE1_WEIGHTS_SIZE == DENSE1_WEIGHT_TILE_SIZE * DENSE1_WEIGHT_TILE_COUNT,
+              "Dense1 weights must map to uniform tiles");
+static_assert(SUBSOLVER0_DENSE2_WEIGHTS_SIZE == DENSE2_WEIGHT_TILE_SIZE * DENSE2_WEIGHT_TILE_COUNT,
+              "Dense2 weights must map to uniform tiles");
+static_assert(SUBSOLVER0_DENSE3_WEIGHTS_SIZE == DENSE3_WEIGHT_TILE_SIZE * DENSE3_WEIGHT_TILE_COUNT,
+              "Dense3 weights must map to uniform tiles");
+
+static constexpr unsigned int TOTAL_WEIGHT_FLOATS = SUBSOLVER0_DENSE0_WEIGHTS_SIZE +
+                                                    SUBSOLVER0_DENSE1_WEIGHTS_SIZE +
+                                                    SUBSOLVER0_DENSE2_WEIGHTS_SIZE +
+                                                    SUBSOLVER0_DENSE3_WEIGHTS_SIZE;
+static constexpr unsigned int TOTAL_WEIGHT_TILES = DENSE0_WEIGHT_TILE_COUNT +
+                                                   DENSE1_WEIGHT_TILE_COUNT +
+                                                   DENSE2_WEIGHT_TILE_COUNT +
+                                                   DENSE3_WEIGHT_TILE_COUNT;
+
+static constexpr unsigned int DENSE0_WEIGHT_OFFSET = 0;
+static constexpr unsigned int DENSE1_WEIGHT_OFFSET = DENSE0_WEIGHT_OFFSET + SUBSOLVER0_DENSE0_WEIGHTS_SIZE;
+static constexpr unsigned int DENSE2_WEIGHT_OFFSET = DENSE1_WEIGHT_OFFSET + SUBSOLVER0_DENSE1_WEIGHTS_SIZE;
+static constexpr unsigned int DENSE3_WEIGHT_OFFSET = DENSE2_WEIGHT_OFFSET + SUBSOLVER0_DENSE2_WEIGHTS_SIZE;
+
+static constexpr unsigned int DENSE0_WEIGHT_TILE_BASE = 0;
+static constexpr unsigned int DENSE1_WEIGHT_TILE_BASE = DENSE0_WEIGHT_TILE_BASE + DENSE0_WEIGHT_TILE_COUNT;
+static constexpr unsigned int DENSE2_WEIGHT_TILE_BASE = DENSE1_WEIGHT_TILE_BASE + DENSE1_WEIGHT_TILE_COUNT;
+static constexpr unsigned int DENSE3_WEIGHT_TILE_BASE = DENSE2_WEIGHT_TILE_BASE + DENSE2_WEIGHT_TILE_COUNT;
+
+static constexpr unsigned int BIAS_TILE_SIZE = SUBSOLVER0_DENSE0_BIAS_SIZE;
+static_assert(BIAS_TILE_SIZE == SUBSOLVER0_DENSE1_BIAS_SIZE, "Dense1 bias slice must match Dense0 size");
+static_assert(BIAS_TILE_SIZE == SUBSOLVER0_DENSE2_BIAS_SIZE, "Dense2 bias slice must match Dense0 size");
+static_assert(BIAS_TILE_SIZE == SUBSOLVER0_DENSE3_BIAS_SIZE, "Dense3 bias slice must match Dense0 size");
+
+static constexpr unsigned int TOTAL_BIAS_FLOATS = SUBSOLVER0_DENSE0_BIAS_SIZE +
+                                                  SUBSOLVER0_DENSE1_BIAS_SIZE +
+                                                  SUBSOLVER0_DENSE2_BIAS_SIZE +
+                                                  SUBSOLVER0_DENSE3_BIAS_SIZE;
+static constexpr unsigned int TOTAL_BIAS_TILES = 4;
+static_assert(TOTAL_BIAS_FLOATS == BIAS_TILE_SIZE * TOTAL_BIAS_TILES,
+              "Bias stream must decompose into uniform layer tiles");
+
+static constexpr unsigned int DENSE0_BIAS_OFFSET = 0;
+static constexpr unsigned int DENSE1_BIAS_OFFSET = DENSE0_BIAS_OFFSET + SUBSOLVER0_DENSE0_BIAS_SIZE;
+static constexpr unsigned int DENSE2_BIAS_OFFSET = DENSE1_BIAS_OFFSET + SUBSOLVER0_DENSE1_BIAS_SIZE;
+static constexpr unsigned int DENSE3_BIAS_OFFSET = DENSE2_BIAS_OFFSET + SUBSOLVER0_DENSE2_BIAS_SIZE;
+
 
 using dense768x128 = matrix_vector_mul_graph<
     float, float,
@@ -74,6 +140,8 @@ using dense128x128 = matrix_vector_mul_graph<
 class NeuralNetworkGraph : public graph {
 public:
     input_plio  layer0_in;
+    input_plio  weights_in;
+    input_plio  biases_in;
     dense768x128 dense0;
     dense128x128 dense1;
     dense128x128 dense2;
@@ -92,15 +160,8 @@ public:
     kernel      k_wsplit1;
     kernel      k_wsplit2;
     adf::shared_buffer<float> roll_concat_buffer;
-
-    input_port matrixA_dense0_rtp[TP_CASC_LEN_LAYER3];
-    input_port bias_dense0_rtp;
-    input_port matrixA_dense1_rtp[TP_CASC_LEN_LAYER2];
-    input_port bias_dense1_rtp;
-    input_port matrixA_dense2_rtp[TP_CASC_LEN_LAYER2];
-    input_port bias_dense2_rtp;
-    input_port matrixA_dense3_rtp[TP_CASC_LEN_LAYER2];
-    input_port bias_dense3_rtp;
+    adf::shared_buffer<float> weights_buffer;
+    adf::shared_buffer<float> bias_buffer;
 
     NeuralNetworkGraph() {
         std::string base_path = DATA_DIR;
@@ -108,6 +169,10 @@ public:
 
         layer0_in      = input_plio::create("layer0_in", plio_32_bits,
             (base_path + "/" + TMP_INP768).c_str());
+        weights_in     = input_plio::create("weights_in", plio_32_bits,
+            (base_path + "/" + SUBSOLVER0_DENSE_WEIGHTS_STREAM).c_str());
+        biases_in      = input_plio::create("biases_in", plio_32_bits,
+            (base_path + "/" + SUBSOLVER0_DENSE_BIASES_STREAM).c_str());
 
 
 
@@ -129,11 +194,57 @@ public:
             .tiling_dimension = {ROLL_CONCAT_TOTAL},
             .offset = {0}
         });
+        weights_buffer = shared_buffer<float>::create({TOTAL_WEIGHT_FLOATS}, 1, TOTAL_WEIGHT_TILES);
+        connect<>(weights_in.out[0], weights_buffer.in[0]);
+        write_access(weights_buffer.in[0]) = tiling({
+            .buffer_dimension = {TOTAL_WEIGHT_FLOATS},
+            .tiling_dimension = {TOTAL_WEIGHT_FLOATS},
+            .offset = {0}
+        });
 
+        bias_buffer = shared_buffer<float>::create({TOTAL_BIAS_FLOATS}, 1, TOTAL_BIAS_TILES);
+        connect<>(biases_in.out[0], bias_buffer.in[0]);
+        write_access(bias_buffer.in[0]) = tiling({
+            .buffer_dimension = {TOTAL_BIAS_FLOATS},
+            .tiling_dimension = {TOTAL_BIAS_FLOATS},
+            .offset = {0}
+        });
 
+        unsigned int weight_tile_idx = 0;
+        for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i, ++weight_tile_idx) {
+            connect<>(weights_buffer.out[weight_tile_idx], dense0.matrixA[i]);
+            read_access(weights_buffer.out[weight_tile_idx]) = tiling({
+                .buffer_dimension = {TOTAL_WEIGHT_FLOATS},
+                .tiling_dimension = {DENSE0_WEIGHT_TILE_SIZE},
+                .offset = {static_cast<int>(DENSE0_WEIGHT_OFFSET + i * DENSE0_WEIGHT_TILE_SIZE)}
+            });
+        }
 
-        for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
-            connect<parameter>(matrixA_dense0_rtp[i], dense0.matrixA[i]);
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i, ++weight_tile_idx) {
+            connect<>(weights_buffer.out[weight_tile_idx], dense1.matrixA[i]);
+            read_access(weights_buffer.out[weight_tile_idx]) = tiling({
+                .buffer_dimension = {TOTAL_WEIGHT_FLOATS},
+                .tiling_dimension = {DENSE1_WEIGHT_TILE_SIZE},
+                .offset = {static_cast<int>(DENSE1_WEIGHT_OFFSET + i * DENSE1_WEIGHT_TILE_SIZE)}
+            });
+        }
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i, ++weight_tile_idx) {
+            connect<>(weights_buffer.out[weight_tile_idx], dense2.matrixA[i]);
+            read_access(weights_buffer.out[weight_tile_idx]) = tiling({
+                .buffer_dimension = {TOTAL_WEIGHT_FLOATS},
+                .tiling_dimension = {DENSE2_WEIGHT_TILE_SIZE},
+                .offset = {static_cast<int>(DENSE2_WEIGHT_OFFSET + i * DENSE2_WEIGHT_TILE_SIZE)}
+            });
+        }
+
+        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i, ++weight_tile_idx) {
+            connect<>(weights_buffer.out[weight_tile_idx], dense3.matrixA[i]);
+            read_access(weights_buffer.out[weight_tile_idx]) = tiling({
+                .buffer_dimension = {TOTAL_WEIGHT_FLOATS},
+                .tiling_dimension = {DENSE3_WEIGHT_TILE_SIZE},
+                .offset = {static_cast<int>(DENSE3_WEIGHT_OFFSET + i * DENSE3_WEIGHT_TILE_SIZE)}
+            });
         }
 
         for (int i = 0; i < TP_CASC_LEN_LAYER3; ++i) {
@@ -200,43 +311,55 @@ public:
         runtime<ratio>(k_wsplit2) = 1.0;
 
         connect<window<512>>(dense0.out[0], k_biasadd0.in[0]);
-        connect<parameter>(bias_dense0_rtp, k_biasadd0.in[1]);
+        connect<>(bias_buffer.out[0], k_biasadd0.in[1]);
+        dimensions(k_biasadd0.in[1]) = {BIAS_TILE_SIZE};
+        read_access(bias_buffer.out[0]) = tiling({
+            .buffer_dimension = {TOTAL_BIAS_FLOATS},
+            .tiling_dimension = {BIAS_TILE_SIZE},
+            .offset = {static_cast<int>(DENSE0_BIAS_OFFSET)}
+        });
         connect<window<512>>(k_biasadd0.out[0], k_lrelu0.in[0]);
         connect<window<512>>(k_lrelu0.out[0], k_wsplit0.in[0]);
 
         connect<window<256>>(k_wsplit0.out[0], dense1.inB[0]);
         connect<window<256>>(k_wsplit0.out[1], dense1.inB[1]);
 
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            connect<parameter>(matrixA_dense1_rtp[i], dense1.matrixA[i]);
-        }
-
         connect<window<512>>(dense1.out[0], k_biasadd1.in[0]);
-        connect<parameter>(bias_dense1_rtp, k_biasadd1.in[1]);
+        connect<>(bias_buffer.out[1], k_biasadd1.in[1]);
+        dimensions(k_biasadd1.in[1]) = {BIAS_TILE_SIZE};
+        read_access(bias_buffer.out[1]) = tiling({
+            .buffer_dimension = {TOTAL_BIAS_FLOATS},
+            .tiling_dimension = {BIAS_TILE_SIZE},
+            .offset = {static_cast<int>(DENSE1_BIAS_OFFSET)}
+        });
         connect<window<512>>(k_biasadd1.out[0], k_lrelu1.in[0]);
         connect<window<512>>(k_lrelu1.out[0], k_wsplit1.in[0]);
 
         connect<window<256>>(k_wsplit1.out[0], dense2.inB[0]);
         connect<window<256>>(k_wsplit1.out[1], dense2.inB[1]);
 
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            connect<parameter>(matrixA_dense2_rtp[i], dense2.matrixA[i]);
-        }
-
         connect<window<512>>(dense2.out[0], k_biasadd2.in[0]);
-        connect<parameter>(bias_dense2_rtp, k_biasadd2.in[1]);
+        connect<>(bias_buffer.out[2], k_biasadd2.in[1]);
+        dimensions(k_biasadd2.in[1]) = {BIAS_TILE_SIZE};
+        read_access(bias_buffer.out[2]) = tiling({
+            .buffer_dimension = {TOTAL_BIAS_FLOATS},
+            .tiling_dimension = {BIAS_TILE_SIZE},
+            .offset = {static_cast<int>(DENSE2_BIAS_OFFSET)}
+        });
         connect<window<512>>(k_biasadd2.out[0], k_lrelu2.in[0]);
         connect<window<512>>(k_lrelu2.out[0], k_wsplit2.in[0]);
 
         connect<window<256>>(k_wsplit2.out[0], dense3.inB[0]);
         connect<window<256>>(k_wsplit2.out[1], dense3.inB[1]);
 
-        for (int i = 0; i < TP_CASC_LEN_LAYER2; ++i) {
-            connect<parameter>(matrixA_dense3_rtp[i], dense3.matrixA[i]);
-        }
-
         connect<window<512>>(dense3.out[0], k_biasadd3.in[0]);
-        connect<parameter>(bias_dense3_rtp, k_biasadd3.in[1]);
+        connect<>(bias_buffer.out[3], k_biasadd3.in[1]);
+        dimensions(k_biasadd3.in[1]) = {BIAS_TILE_SIZE};
+        read_access(bias_buffer.out[3]) = tiling({
+            .buffer_dimension = {TOTAL_BIAS_FLOATS},
+            .tiling_dimension = {BIAS_TILE_SIZE},
+            .offset = {static_cast<int>(DENSE3_BIAS_OFFSET)}
+        });
         connect<window<512>>(k_biasadd3.out[0], k_lrelu3.in[0]);
 
         connect<window<512>>(k_lrelu3.out[0], layer_out.in[0]);

--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -35,10 +35,12 @@
 #define SUBSOLVER0_LEAKYRELU_2_PREFIX  "solver_0_leakyrelu_2_output_part"
 #define SUBSOLVER0_DENSE3_WEIGHTS_PREFIX "solver_0_dense_3_weights_part"
 #define SUBSOLVER0_DENSE3_OUTPUT       "solver_0_dense_3_output_aie.txt"
+#define SUBSOLVER0_DENSE_WEIGHTS_STREAM "solver_0_dense_weights_stream.txt"
 #define SUBSOLVER0_DENSE0_BIAS         "solver_0_dense_0_bias.txt"
 #define SUBSOLVER0_DENSE1_BIAS         "solver_0_dense_1_bias.txt"
 #define SUBSOLVER0_DENSE2_BIAS         "solver_0_dense_2_bias.txt"
 #define SUBSOLVER0_DENSE3_BIAS         "solver_0_dense_3_bias.txt"
+#define SUBSOLVER0_DENSE_BIASES_STREAM  "solver_0_dense_biases_stream.txt"
 #define SUBSOLVER0_HOST_OUTPUT         "solver_0_host_output.txt"
 
 // OUTPUT graph files ------------------------------------------------------


### PR DESCRIPTION
## Summary
- generate unified weight and bias streams in the aieml7 simulator before initializing the graph
- stage concatenated matrices and biases through new shared-buffer tiling that feeds every dense cascade and bias kernel
- document the streaming workflow and export the shared filenames for reuse across the project

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68defe4ee26c832081d105f9360501bf