### PR TITLE
Fix AIEML7 weight copy kernels for host compilation

### DIFF
--- a/aieml7/README.md
+++ b/aieml7/README.md
@@ -1,25 +1,26 @@
 # AI Engine-ML Graph: Four-Layer Neural Network with Roll-Concat
 
-This directory implements a four-layer neural network graph featuring a roll-concat operation and shared buffer tiling for efficient memory access across a large cascaded matrix multiply.
+This directory implements a four-layer neural network graph featuring a roll-concat operation and shared-buffer tiling for efficient memory access across a large cascaded matrix multiply.  The project has recently been refactored to stage all dense-layer weights through AI Engine shared buffers before fanning them out into the per-leg local windows that the DSPLib matrix-vector multiply blocks expect.
 
 ## Architecture
 
 ### Pipeline
-1. **`roll_concat`** – Repeats input 128-element vector 6 times to create 768 elements
-2. **`dense0`** (768×128, cascade length=12) – Large matrix-vector multiply with shared buffer input
-3. **`bias_add`** → **`leaky_relu`** → **`window_split_128_to_64x2`**
-4. **`dense1`** (128×128, cascade length=2) – Second dense layer
-5. **`bias_add`** → **`leaky_relu`** → **`window_split_128_to_64x2`**
-6. **`dense2`** (128×128, cascade length=2) – Third dense layer
-7. **`bias_add`** → **`leaky_relu`** → **`window_split_128_to_64x2`**
-8. **`dense3`** (128×128, cascade length=2) – Fourth dense layer
-9. **`bias_add`** → **`leaky_relu`** – Final output
+1. **`roll_concat`** – Repeats the 128-element input vector six times to create 768 elements and writes the result into a shared buffer that is tiled across the 12 cascaded legs of the first dense layer.
+2. **Weight preload** – Three PLIOs (`preload_w768_lo`, `preload_w768_hi`, `preload_w128_all`) stream weight banks into AI Engine shared buffers.  Dedicated copy kernels (`copy768_lo`, `copy768_hi`, `copy128_all`) then fan out the staged data into six local windows per bank, matching the number of cascade legs or matrix partitions.
+3. **`dense0`** (768×128, cascade length = 12) – Large matrix-vector multiply that reads its weights from the distributed local windows and its activation input from the shared roll-concat buffer.
+4. **`bias_add` → `leaky_relu` → `window_split_128_to_64x2`** – Post-processing for layer 0.
+5. **`dense1`** (128×128, cascade length = 2) – Second dense layer, using weights sourced from the `copy128_all` fan-out.
+6. **`bias_add` → `leaky_relu` → `window_split_128_to_64x2`** – Post-processing for layer 1.
+7. **`dense2`** (128×128, cascade length = 2) – Third dense layer.
+8. **`bias_add` → `leaky_relu` → `window_split_128_to_64x2`** – Post-processing for layer 2.
+9. **`dense3`** (128×128, cascade length = 2) – Fourth dense layer.
+10. **`bias_add` → `leaky_relu`** – Final activation producing the 128-element output.
 
 ### Key Features
-- **Shared Buffer**: 768-element buffer tiled across 12 cascade kernels for dense0
-- **Roll-Concat**: Efficiently replicates 128→768 elements for large matrix input
-- **4 Dense Layers**: Progressive transformation from 768 inputs to 128 outputs
-- All weights loaded via RTP (runtime parameters)
+- **Shared roll-concat buffer**: The 768-element activation is written once then tiled across the 12 cascade kernels in `dense0`.
+- **Weight staging via copy kernels**: All dense-layer weights are streamed in through PLIOs, stored in shared buffers, and redistributed with lightweight copy kernels that keep port pressure low while feeding the DSPLib blocks.
+- **Four dense layers with leaky-ReLU activations**: The network transforms the 768-element rolled input down to 128 outputs.
+- **Runtime bias updates**: Biases for each dense layer are provided through RTP connections so they can be updated without recompiling the graph.
 
 ### Layer Configurations
 - **Layer 0**: 768×128 dense layer with 12-way cascade (TP_CASC_LEN_LAYER3=12)
@@ -36,7 +37,8 @@ This directory implements a four-layer neural network graph featuring a roll-con
 ├── bias_add.cpp/.h                 # Bias addition kernel
 ├── window_split_128_to_64x2.cpp/.h # Window splitter for cascade inputs
 ├── roll_concat.cpp/.h              # Roll-concat kernel (128→768)
-├── window_split_768_to_*.h         # Additional window split utilities (unused)
+├── copy_to_locals_6.cpp/.h         # Weight fan-out kernels for preload buffers
+├── window_split_768_to_*.h         # Additional window split utilities (optional experiments)
 ├── aie.cfg                         # AIE compiler configuration
 └── Makefile                        # Build targets
 ```
@@ -48,7 +50,7 @@ This directory implements a four-layer neural network graph featuring a roll-con
 cd aieml7
 make graph TARGET=hw       # or TARGET=hw_emu
 ```
-Produces `Work/libadf.a` containing the compiled graph.
+This invokes `v++` to produce `Work/libadf.a`.  The command requires a Vitis installation in the environment; if `v++` is unavailable you will see `command not found`.
 
 ### Run AI Engine Simulation
 ```bash
@@ -62,15 +64,13 @@ make sim
 - **Output**: `layer_out` writes to `../data/subsolver_0_dense_3_output_aie.txt` (128 floats)
 
 ### Runtime Parameters (RTP)
-Weights provided via RTP connections:
-- `matrixA_dense0_rtp[12]`: Twelve weight matrices for 12-way cascaded dense0
+Only the biases are updated at run time via RTP connections in the current configuration:
 - `bias_dense0_rtp`: 128-element bias for dense0
-- `matrixA_dense1_rtp[2]`: Two weight matrices for 2-way cascaded dense1
 - `bias_dense1_rtp`: 128-element bias for dense1
-- `matrixA_dense2_rtp[2]`: Two weight matrices for 2-way cascaded dense2
 - `bias_dense2_rtp`: 128-element bias for dense2
-- `matrixA_dense3_rtp[2]`: Two weight matrices for 2-way cascaded dense3
 - `bias_dense3_rtp`: 128-element bias for dense3
+
+The dense-layer weight matrices are streamed through the preload PLIOs and staged in shared buffers before execution begins.
 
 ### Processing Pipeline
 ```

--- a/aieml7/copy_to_locals_6.cpp
+++ b/aieml7/copy_to_locals_6.cpp
@@ -1,40 +1,62 @@
 
+#include <aie_api/aie_adf.hpp>
+
 #include "nn_defs.h"
 #include "copy_to_locals_6.h"
 
-// Instantiate the two flavors we need:
+namespace {
+
+template <int BLOCK>
+inline void copy_to_locals_6_impl(input_window<float>* __restrict in,
+                                  output_window<float>* __restrict o0,
+                                  output_window<float>* __restrict o1,
+                                  output_window<float>* __restrict o2,
+                                  output_window<float>* __restrict o3,
+                                  output_window<float>* __restrict o4,
+                                  output_window<float>* __restrict o5) {
+  output_window<float>* outs[6] = {o0, o1, o2, o3, o4, o5};
+
+  for (int b = 0; b < 6; ++b) {
+    for (int i = 0; i < BLOCK; ++i) {
+      float v = window_readincr(in);
+      window_writeincr(outs[b], v);
+    }
+  }
+}
+
+}  // namespace
+
+// Instantiate the kernel variants required by graph.h.
 extern "C" {
 
-// 768x128 bank → 6 x 8192-float legs
-void copy768_lo(input_window<float>*  __restrict in,
+void copy768_lo(input_window<float>* __restrict in,
                 output_window<float>* __restrict o0,
                 output_window<float>* __restrict o1,
                 output_window<float>* __restrict o2,
                 output_window<float>* __restrict o3,
                 output_window<float>* __restrict o4,
                 output_window<float>* __restrict o5) {
-  copy_to_locals_6<FLOATS_PER_D768_LEG>(in,o0,o1,o2,o3,o4,o5);
+  copy_to_locals_6_impl<FLOATS_PER_D768_LEG>(in, o0, o1, o2, o3, o4, o5);
 }
 
-void copy768_hi(input_window<float>*  __restrict in,
+void copy768_hi(input_window<float>* __restrict in,
                 output_window<float>* __restrict o0,
                 output_window<float>* __restrict o1,
                 output_window<float>* __restrict o2,
                 output_window<float>* __restrict o3,
                 output_window<float>* __restrict o4,
                 output_window<float>* __restrict o5) {
-  copy_to_locals_6<FLOATS_PER_D768_LEG>(in,o0,o1,o2,o3,o4,o5);
+  copy_to_locals_6_impl<FLOATS_PER_D768_LEG>(in, o0, o1, o2, o3, o4, o5);
 }
 
-// 128x128 all layers (3×2 parts) → treat as 6 blocks of 8192 floats
-void copy128_all(input_window<float>*  __restrict in,
+void copy128_all(input_window<float>* __restrict in,
                  output_window<float>* __restrict o0,
                  output_window<float>* __restrict o1,
                  output_window<float>* __restrict o2,
                  output_window<float>* __restrict o3,
                  output_window<float>* __restrict o4,
                  output_window<float>* __restrict o5) {
-  copy_to_locals_6<FLOATS_PER_D128_PART>(in,o0,o1,o2,o3,o4,o5);
+  copy_to_locals_6_impl<FLOATS_PER_D128_PART>(in, o0, o1, o2, o3, o4, o5);
 }
 
-} // extern "C"
+}  // extern "C"

--- a/aieml7/copy_to_locals_6.h
+++ b/aieml7/copy_to_locals_6.h
@@ -1,21 +1,36 @@
 #pragma once
 #include <adf.h>
-#include <aie_api/aie_adf.hpp>  // <-- use aie_adf for window_* intrinsics
+
 using namespace adf;
 
-// Copies 6 contiguous blocks of BLOCK floats from one input window
-// into 6 output windows, sequentially (low port pressure).
-template<int BLOCK>
-void copy_to_locals_6(input_window<float>* __restrict in,
-                      output_window<float>* __restrict o0,
-                      output_window<float>* __restrict o1,
-                      output_window<float>* __restrict o2,
-                      output_window<float>* __restrict o3,
-                      output_window<float>* __restrict o4,
-                      output_window<float>* __restrict o5) {
-  output_window<float>* outs[6] = {o0,o1,o2,o3,o4,o5};
-  for (int b = 0; b < 6; ++b) {
-    for (int i = 0; i < BLOCK; ++i)
-      window_writeincr(outs[b], window_readincr(in));
-  }
+// Expose the kernels that fan out matrix weights from the preload buffers
+// into per-leg local memories.  The implementations live in
+// copy_to_locals_6.cpp, so this header remains safe to include from graph
+// construction code that is compiled for x86.
+extern "C" {
+
+void copy768_lo(input_window<float>*  __restrict in,
+                output_window<float>* __restrict o0,
+                output_window<float>* __restrict o1,
+                output_window<float>* __restrict o2,
+                output_window<float>* __restrict o3,
+                output_window<float>* __restrict o4,
+                output_window<float>* __restrict o5);
+
+void copy768_hi(input_window<float>*  __restrict in,
+                output_window<float>* __restrict o0,
+                output_window<float>* __restrict o1,
+                output_window<float>* __restrict o2,
+                output_window<float>* __restrict o3,
+                output_window<float>* __restrict o4,
+                output_window<float>* __restrict o5);
+
+void copy128_all(input_window<float>*  __restrict in,
+                 output_window<float>* __restrict o0,
+                 output_window<float>* __restrict o1,
+                 output_window<float>* __restrict o2,
+                 output_window<float>* __restrict o3,
+                 output_window<float>* __restrict o4,
+                 output_window<float>* __restrict o5);
+
 }

--- a/aieml7/graph.h
+++ b/aieml7/graph.h
@@ -15,7 +15,7 @@
 
 #include <adf/io_buffer/io_buffer.h>      // defines adf::buffer
 #include <adf/io_buffer/io_buffer_extents.h> // defines extents<...>
-#include <adf/window/window.h>   
+#include <adf/window/types.h>             // lightweight window<> definition
 
 using namespace adf;
 using namespace xf::dsp::aie::blas::matrix_vector_mul;


### PR DESCRIPTION
## Summary
- move the copy_to_locals helper logic into the implementation file so the host-side graph build no longer sees AI Engine window intrinsics
- switch the graph header to the lightweight window type include and refresh the README to document the new weight preload staging flow

## Testing
- make graph *(fails: v++: command not found in the container image)*

------
https://chatgpt.com/codex/tasks/task_e_68e008d102a48320b00d15f3224c7ab3