### PR TITLE
Split roll-concat data across dual shared buffers

### DIFF
--- a/aieml7/roll_concat.cpp
+++ b/aieml7/roll_concat.cpp
@@ -4,7 +4,8 @@
 using namespace adf;
 
 void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
-                        adf::output_buffer<float>& __restrict out) {
+                        adf::output_buffer<float>& __restrict out0,
+                        adf::output_buffer<float>& __restrict out1) {
   constexpr int N = HIDDEN_SIZE;
   constexpr int K = ROLL_CONC_SUBSET_SIZE;
 
@@ -16,11 +17,14 @@ void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
   }
 
   // Write K rolled views back-to-back as a single output buffer of size N*K
-  auto outIt = aie::begin(out);
+  auto outIt0 = aie::begin(out0);
+  auto outIt1 = aie::begin(out1);
   for (int shift = 0; shift < K; ++shift) {
     for (int i = 0; i < N; ++i) {
       const int idx = (i + shift) % N;
-      *outIt++ = buf[idx];
+      const float value = buf[idx];
+      *outIt0++ = value;
+      *outIt1++ = value;
     }
   }
 }

--- a/aieml7/roll_concat.h
+++ b/aieml7/roll_concat.h
@@ -5,6 +5,9 @@
 using namespace adf;
 
 // Reads one buffer of HIDDEN_SIZE floats and emits
-// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one buffer).
+// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one buffer)
+// on two output buffers so that multiple shared buffers can consume the
+// generated tiles.
 void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
-                        adf::output_buffer<float>& __restrict out);
+                        adf::output_buffer<float>& __restrict out0,
+                        adf::output_buffer<float>& __restrict out1);


### PR DESCRIPTION
## Summary
- update the roll-concat kernel to duplicate its output stream onto two ports
- drive two shared buffers from the kernel and fan their outputs to six dense0 cascade legs each
- preserve the existing tiling offsets while ensuring each buffer services half of the consumers

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4020b87008320aca814cb15ce53d7