### PR TITLE
Add integrated aieml9 AI Engine graph

### DIFF
--- a/aieml9/Makefile
+++ b/aieml9/Makefile
@@ -1,0 +1,109 @@
+# ===================================================================
+# Makefile for Vitis AIE Graph Compilation & Simulation
+# ===================================================================
+
+SHELL := /bin/bash
+
+# ==== CONFIG ====
+# Target platform for hardware compilation.
+PLATFORM     ?= /tools/Xilinx/Vitis/2024.2/base_platforms/xilinx_vek280_base_202420_1/xilinx_vek280_base_202420_1.xpfm
+
+# Target for compilation. Options: hw, hw_emu
+TARGET       ?= hw
+
+# Location of input/weight files used by PLIO connections (override from top-level)
+# Defaults to the data directory in the parent rtda_demo directory
+DATA_DIR    ?= ../data
+DATA_DIR := $(abspath $(DATA_DIR))
+
+# Path to your Vitis installation.
+VITIS_PATH   ?= /tools/Xilinx/Vitis/2024.2
+
+# ##########################################################################
+# ##########################################################################
+#
+#   >>> IMPORTANT: YOU MUST EDIT THIS LINE <<<
+#   Set this variable to the correct path for the Vitis_Libraries on your system.
+#   Example: DSPLIB_PATH  ?= /home/user/vitis/Vitis_Libraries/dsp
+#
+# ##########################################################################
+DSPLIB_PATH  ?= ../dsp_lib
+
+
+# ==== PROJECT FILES & DIRECTORIES ====
+GRAPH_SRC     := graph.cpp
+WORK_DIR      := Work
+GRAPH_LIB     := $(WORK_DIR)/libadf.a
+AIE_CFG       := aie.cfg
+KERNEL_SRCS   := \
+	leaky_relu.cpp \
+	bias_add.cpp \
+	window_split_128_to_64x2.cpp \
+	roll_concat.cpp
+KERNEL_HDRS   := $(KERNEL_SRCS:.cpp=.h)
+
+
+# ==== TOOLS ====
+VPP          := v++
+AIESIM       := aiesimulator
+
+
+# ==== COMPILER FLAGS ====
+# Include paths for the AIE compiler.
+AIE_INCLUDE_FLAGS := \
+	--include="./" \
+	--include="../common" \
+	--include="$(DSPLIB_PATH)/L1/src/aie" \
+	--include="$(DSPLIB_PATH)/L1/include/aie" \
+	--include="$(DSPLIB_PATH)/L2/include/aie"
+
+# Full v++ command flags, assembled from variables above.
+VPP_FLAGS := \
+	-c \
+	--mode aie \
+	--target=$(TARGET) \
+	--platform=$(PLATFORM) \
+	--work_dir=$(WORK_DIR) \
+	--config=$(AIE_CFG) \
+	$(AIE_INCLUDE_FLAGS)
+
+
+# ==== RULES ====
+
+.PHONY: all graph sim clean
+
+# --- Default Target ---
+all: graph
+
+# --- AIE Graph Compilation ---
+graph: $(GRAPH_LIB)
+
+$(GRAPH_LIB): $(GRAPH_SRC) $(KERNEL_SRCS) $(KERNEL_HDRS) graph.h ../common/nn_defs.h ../common/data_paths.h $(AIE_CFG)
+	@mkdir -p $(WORK_DIR)
+	@echo "--- Compiling AIEML9 AIE Graph for TARGET=$(TARGET) ---"
+	@echo "INFO: Using Vitis DSP Library Path: $(DSPLIB_PATH)"
+	@if [ ! -d "$(DSPLIB_PATH)" ]; then \
+		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		echo "!!! ERROR: Directory not found: '$(DSPLIB_PATH)'"; \
+		echo "!!! Please set the DSPLIB_PATH variable in your Makefile correctly."; \
+		echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"; \
+		exit 1; \
+	fi
+	@set -o pipefail; \
+	$(VPP) $(VPP_FLAGS) $(GRAPH_SRC) $(KERNEL_SRCS) 2>&1 | tee $(WORK_DIR)/vpp_aie.log
+	@echo "COMPLETE: AIE graph compiled."
+
+# --- Simulation ---
+sim: graph
+	@echo "--- Starting AIEML9 AI Engine simulation (aiesimulator) ---"
+	DATA_DIR=$(abspath $(DATA_DIR)) $(AIESIM) --pkg-dir=$(WORK_DIR) --profile --dump-vcd=foo --output-time-stamp=no
+	@echo "COMPLETE: AI Engine simulation finished."
+
+# --- Clean Target ---
+clean:
+	@echo "--- Cleaning Workspace ---"
+	rm -rf $(WORK_DIR) .Xil *.log *.csv *.db *.aiecompile_summary \
+	       aiesimulator_output build_hw \
+	       pl_sample* *.a .AIE_SIM_CMD_LINE_OPTIONS ISS_RPC_SERVER_PORT \
+	       *.json *.vcd
+	@echo "CLEANED: Build and work directories removed."

--- a/aieml9/README.md
+++ b/aieml9/README.md
@@ -1,0 +1,15 @@
+# AIEML9 Combined Graph
+
+`aieml9` stitches together the three existing AI Engine stages (`aieml6`,
+`aieml7`, and `aieml8`) into a single graph. The embedded feature extractor,
+solver stack, and output projection now execute in a single compilation unit so
+that `make graph` builds the whole network in one go.
+
+## Build
+
+```bash
+make graph
+```
+
+The graph expects the same data files as the original projects. The final
+result is dumped to `data/aieml9_output_aie.txt`.

--- a/aieml9/aie.cfg
+++ b/aieml9/aie.cfg
@@ -1,0 +1,2 @@
+[aie]
+enable-partition=6:22:aieml9

--- a/aieml9/bias_add.cpp
+++ b/aieml9/bias_add.cpp
@@ -1,0 +1,14 @@
+#include "bias_add.h"
+
+void bias_add_kernel(input_window<float>* __restrict dense_window,
+                    output_window<float>* __restrict biased_window,
+                    const float (&bias)[HIDDEN_SIZE])
+{
+    // Process one window of HIDDEN_SIZE floats
+    for (int i = 0; i < HIDDEN_SIZE; ++i) {
+        float x = window_readincr(dense_window);
+        float y = x + bias[i];
+        window_writeincr(biased_window, y);
+    }
+}
+                     

--- a/aieml9/bias_add.h
+++ b/aieml9/bias_add.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+using namespace adf;
+
+void bias_add_kernel(input_window<float>* __restrict dense_window,
+                     output_window<float>* __restrict biased_window,
+                     const float (&bias)[HIDDEN_SIZE]);

--- a/aieml9/graph.cpp
+++ b/aieml9/graph.cpp
@@ -1,0 +1,119 @@
+#include "graph.h"
+#include "data_paths.h"
+#include "nn_defs.h"
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+NeuralNetworkGraph g;
+
+#if defined(__AIESIM__) || defined(__X86SIM__)
+int main() {
+  auto loadValues = [](const std::string& path, std::size_t expectedCount) -> std::vector<float> {
+    std::ifstream file(path);
+    if (!file.is_open()) {
+      std::cerr << "Error: Could not open file '" << path << "'" << std::endl;
+      return {};
+    }
+
+    std::vector<float> values;
+    values.reserve(expectedCount);
+    float value = 0.0f;
+    while (file >> value) {
+      values.push_back(value);
+    }
+
+    if (values.size() != expectedCount) {
+      std::cerr << "Error: Expected " << expectedCount << " values from '" << path
+                << "', got " << values.size() << std::endl;
+      return {};
+    }
+    return values;
+  };
+
+  g.init();
+  const std::string basePath = std::string(DATA_DIR) + "/";
+
+  // Stage 1 weights and bias updates ---------------------------------------
+  {
+    const auto weights = loadValues(basePath + EMBED_DENSE0_WEIGHTS, EMBED_DENSE0_WEIGHTS_SIZE);
+    if (weights.empty()) {
+      return -1;
+    }
+    g.update(g.embed_matrixA_rtp, weights.data(), EMBED_DENSE0_WEIGHTS_SIZE);
+  }
+
+  {
+    const auto bias = loadValues(basePath + EMBED_DENSE0_BIAS, EMBED_DENSE0_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.embed_bias0_rtp, bias.data(), EMBED_DENSE0_BIAS_SIZE);
+  }
+
+  for (int cascIdx = 0; cascIdx < TP_CASC_LEN_STAGE1_LAYER1; ++cascIdx) {
+    const std::string weightPath = basePath + EMBED_DENSE1_WEIGHTS_PREFIX + std::to_string(cascIdx) + ".txt";
+    const auto weights = loadValues(weightPath, EMBED_DENSE1_WEIGHTS_PART_SIZE);
+    if (weights.empty()) {
+      return -1;
+    }
+    g.update(g.embed_matrixA1_rtp[cascIdx], weights.data(), EMBED_DENSE1_WEIGHTS_PART_SIZE);
+  }
+
+  {
+    const auto bias = loadValues(basePath + EMBED_DENSE1_BIAS, EMBED_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.embed_bias1_rtp, bias.data(), EMBED_DENSE1_BIAS_SIZE);
+  }
+
+  // Stage 2 bias updates ----------------------------------------------------
+  {
+    const auto bias = loadValues(basePath + SUBSOLVER0_DENSE0_BIAS, SUBSOLVER0_DENSE0_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.solver_bias0_rtp, bias.data(), SUBSOLVER0_DENSE0_BIAS_SIZE);
+  }
+
+  {
+    const auto bias = loadValues(basePath + SUBSOLVER0_DENSE1_BIAS, SUBSOLVER0_DENSE1_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.solver_bias1_rtp, bias.data(), SUBSOLVER0_DENSE1_BIAS_SIZE);
+  }
+
+  {
+    const auto bias = loadValues(basePath + SUBSOLVER0_DENSE2_BIAS, SUBSOLVER0_DENSE2_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.solver_bias2_rtp, bias.data(), SUBSOLVER0_DENSE2_BIAS_SIZE);
+  }
+
+  {
+    const auto bias = loadValues(basePath + SUBSOLVER0_DENSE3_BIAS, SUBSOLVER0_DENSE3_BIAS_SIZE);
+    if (bias.empty()) {
+      return -1;
+    }
+    g.update(g.solver_bias3_rtp, bias.data(), SUBSOLVER0_DENSE3_BIAS_SIZE);
+  }
+
+  // Stage 3 weight updates --------------------------------------------------
+  {
+    const auto weights = loadValues(basePath + OUTPUT_DENSE0_WEIGHTS, OUTPUT_DENSE0_WEIGHTS_SIZE);
+    if (weights.empty()) {
+      return -1;
+    }
+    g.update(g.output_matrixA_rtp, weights.data(), OUTPUT_DENSE0_WEIGHTS_SIZE);
+  }
+
+  g.run(1);
+  g.wait();
+  g.end();
+  return 0;
+}
+#endif

--- a/aieml9/graph.h
+++ b/aieml9/graph.h
@@ -1,0 +1,432 @@
+#pragma once
+#include <adf.h>
+#include <array>
+#include <string>
+
+#include "nn_defs.h"
+#include "data_paths.h"
+#include "matrix_vector_mul_graph.hpp"
+#include "aie_api/aie_adf.hpp"
+
+#include "leaky_relu.h"
+#include "window_split_128_to_64x2.h"
+#include "roll_concat.h"
+#include "bias_add.h"
+
+using namespace adf;
+using namespace xf::dsp::aie::blas::matrix_vector_mul;
+
+// Stage 1 (aieml6) configuration ------------------------------------------------
+static constexpr unsigned int TP_SHIFT_STAGE1 = 0;
+static constexpr unsigned int TP_RND_STAGE1 = rnd_floor;
+static constexpr unsigned int TP_NUM_FRAMES_STAGE1 = 1;
+static constexpr unsigned int TP_SAT_STAGE1 = 0;
+static constexpr unsigned int TP_SSR_STAGE1 = 1;
+static constexpr unsigned int TP_DIM_A_LEADING_STAGE1 = 1;
+static constexpr unsigned int TP_USE_MATRIX_RELOAD_STAGE1 = 1;
+static constexpr unsigned int TP_API_STAGE1 = 0;
+static constexpr unsigned int TP_DUAL_IP_STAGE1 = 0;
+static constexpr unsigned int TP_NUM_OUTPUTS_STAGE1 = 1;
+static constexpr unsigned int TP_CASC_LEN_STAGE1_LAYER0 = 1;
+static constexpr unsigned int TP_CASC_LEN_STAGE1_LAYER1 = 2;
+
+using dense8x128 = matrix_vector_mul_graph<
+    float, float,
+    HIDDEN_SIZE,
+    INPUT_SIZE,
+    TP_SHIFT_STAGE1,
+    TP_RND_STAGE1,
+    TP_NUM_FRAMES_STAGE1,
+    TP_CASC_LEN_STAGE1_LAYER0,
+    TP_SAT_STAGE1,
+    TP_SSR_STAGE1,
+    TP_DIM_A_LEADING_STAGE1,
+    TP_USE_MATRIX_RELOAD_STAGE1,
+    TP_API_STAGE1,
+    TP_DUAL_IP_STAGE1,
+    TP_NUM_OUTPUTS_STAGE1>;
+
+using dense128x128_stage1 = matrix_vector_mul_graph<
+    float, float,
+    OUTPUT_SIZE,
+    HIDDEN_SIZE,
+    TP_SHIFT_STAGE1,
+    TP_RND_STAGE1,
+    TP_NUM_FRAMES_STAGE1,
+    TP_CASC_LEN_STAGE1_LAYER1,
+    TP_SAT_STAGE1,
+    TP_SSR_STAGE1,
+    TP_DIM_A_LEADING_STAGE1,
+    TP_USE_MATRIX_RELOAD_STAGE1,
+    TP_API_STAGE1,
+    TP_DUAL_IP_STAGE1,
+    TP_NUM_OUTPUTS_STAGE1>;
+
+// Stage 2 (aieml7) configuration ------------------------------------------------
+static constexpr unsigned int TP_SHIFT_STAGE2 = 0;
+static constexpr unsigned int TP_RND_STAGE2 = rnd_floor;
+static constexpr unsigned int TP_NUM_FRAMES_STAGE2 = 1;
+static constexpr unsigned int TP_SAT_STAGE2 = 0;
+static constexpr unsigned int TP_SSR_STAGE2 = 1;
+static constexpr unsigned int TP_DIM_A_LEADING_STAGE2 = 1;
+static constexpr unsigned int TP_USE_MATRIX_RELOAD_STAGE2 = 0;
+static constexpr unsigned int TP_API_STAGE2 = 0;
+static constexpr unsigned int TP_DUAL_IP_STAGE2 = 0;
+static constexpr unsigned int TP_NUM_OUTPUTS_STAGE2 = 1;
+static constexpr unsigned int TP_CASC_LEN_STAGE2_LAYER0 = 12;
+static constexpr unsigned int TP_CASC_LEN_STAGE2_LAYERX = 2;
+static_assert(TP_CASC_LEN_STAGE2_LAYER0 % 2 == 0,
+              "TP_CASC_LEN_STAGE2_LAYER0 must be even to split across shared buffers");
+static constexpr unsigned int TP_CASC_PER_BUFFER = TP_CASC_LEN_STAGE2_LAYER0 / 2;
+static_assert((ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE) % TP_CASC_LEN_STAGE2_LAYER0 == 0,
+              "ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE must be divisible by TP_CASC_LEN_STAGE2_LAYER0");
+static constexpr unsigned int ROLL_CONCAT_TOTAL = ROLL_CONC_SUBSET_SIZE * HIDDEN_SIZE;
+static constexpr unsigned int ROLL_CONCAT_TILE_SPAN = ROLL_CONCAT_TOTAL / TP_CASC_LEN_STAGE2_LAYER0;
+static_assert(ROLL_CONCAT_TILE_SPAN * TP_CASC_LEN_STAGE2_LAYER0 == ROLL_CONCAT_TOTAL,
+              "Shared buffer tiling must cover the entire roll-concat frame");
+
+using dense768x128 = matrix_vector_mul_graph<
+    float, float,
+    128,
+    768,
+    TP_SHIFT_STAGE2,
+    TP_RND_STAGE2,
+    TP_NUM_FRAMES_STAGE2,
+    TP_CASC_LEN_STAGE2_LAYER0,
+    TP_SAT_STAGE2,
+    TP_SSR_STAGE2,
+    TP_DIM_A_LEADING_STAGE2,
+    TP_USE_MATRIX_RELOAD_STAGE2,
+    TP_API_STAGE2,
+    TP_DUAL_IP_STAGE2,
+    TP_NUM_OUTPUTS_STAGE2>;
+
+using dense128x128_stage2 = matrix_vector_mul_graph<
+    float, float,
+    OUTPUT_SIZE,
+    HIDDEN_SIZE,
+    TP_SHIFT_STAGE2,
+    TP_RND_STAGE2,
+    TP_NUM_FRAMES_STAGE2,
+    TP_CASC_LEN_STAGE2_LAYERX,
+    TP_SAT_STAGE2,
+    TP_SSR_STAGE2,
+    TP_DIM_A_LEADING_STAGE2,
+    TP_USE_MATRIX_RELOAD_STAGE2,
+    TP_API_STAGE2,
+    TP_DUAL_IP_STAGE2,
+    TP_NUM_OUTPUTS_STAGE2>;
+
+// Stage 3 (aieml8) configuration ------------------------------------------------
+static constexpr unsigned int TP_SHIFT_STAGE3 = 0;
+static constexpr unsigned int TP_RND_STAGE3 = rnd_floor;
+static constexpr unsigned int TP_NUM_FRAMES_STAGE3 = 1;
+static constexpr unsigned int TP_SAT_STAGE3 = 0;
+static constexpr unsigned int TP_SSR_STAGE3 = 1;
+static constexpr unsigned int TP_DIM_A_LEADING_STAGE3 = 1;
+static constexpr unsigned int TP_USE_MATRIX_RELOAD_STAGE3 = 1;
+static constexpr unsigned int TP_API_STAGE3 = 0;
+static constexpr unsigned int TP_DUAL_IP_STAGE3 = 0;
+static constexpr unsigned int TP_NUM_OUTPUTS_STAGE3 = 1;
+static constexpr unsigned int TP_CASC_LEN_STAGE3 = 1;
+
+using dense128x32 = matrix_vector_mul_graph<
+    float, float,
+    32,
+    HIDDEN_SIZE,
+    TP_SHIFT_STAGE3,
+    TP_RND_STAGE3,
+    TP_NUM_FRAMES_STAGE3,
+    TP_CASC_LEN_STAGE3,
+    TP_SAT_STAGE3,
+    TP_SSR_STAGE3,
+    TP_DIM_A_LEADING_STAGE3,
+    TP_USE_MATRIX_RELOAD_STAGE3,
+    TP_API_STAGE3,
+    TP_DUAL_IP_STAGE3,
+    TP_NUM_OUTPUTS_STAGE3>;
+
+class NeuralNetworkGraph : public graph {
+public:
+    // Top-level I/O
+    input_plio  pipeline_in;
+    output_plio pipeline_out;
+
+    // Stage 1 modules -------------------------------------------------------
+    dense8x128            embed_dense0;
+    dense128x128_stage1   embed_dense1;
+    kernel                embed_bias0;
+    kernel                embed_bias1;
+    kernel                embed_relu0;
+    kernel                embed_relu1;
+    kernel                embed_split0;
+
+    input_port            embed_matrixA_rtp;
+    input_port            embed_bias0_rtp;
+    input_port            embed_bias1_rtp;
+    input_port            embed_matrixA1_rtp[TP_CASC_LEN_STAGE1_LAYER1];
+
+    // Stage 2 modules -------------------------------------------------------
+    dense768x128          solver_dense0;
+    dense128x128_stage2   solver_dense1;
+    dense128x128_stage2   solver_dense2;
+    dense128x128_stage2   solver_dense3;
+
+    kernel                solver_rollconcat;
+    kernel                solver_bias0;
+    kernel                solver_bias1;
+    kernel                solver_bias2;
+    kernel                solver_bias3;
+    kernel                solver_relu0;
+    kernel                solver_relu1;
+    kernel                solver_relu2;
+    kernel                solver_relu3;
+    kernel                solver_split0;
+    kernel                solver_split1;
+    kernel                solver_split2;
+
+    adf::shared_buffer<float> solver_roll_buf_a;
+    adf::shared_buffer<float> solver_roll_buf_b;
+
+    input_port            solver_bias0_rtp;
+    input_port            solver_bias1_rtp;
+    input_port            solver_bias2_rtp;
+    input_port            solver_bias3_rtp;
+
+    std::array<input_plio, SUBSOLVER0_INPUT_PARTS>         solver_dense0_weight_plios;
+    std::array<input_plio, SUBSOLVER0_LAYER_WEIGHTS_PARTS> solver_dense1_weight_plios;
+    std::array<input_plio, SUBSOLVER0_LAYER_WEIGHTS_PARTS> solver_dense2_weight_plios;
+    std::array<input_plio, SUBSOLVER0_LAYER_WEIGHTS_PARTS> solver_dense3_weight_plios;
+
+    // Stage 3 modules -------------------------------------------------------
+    dense128x32           output_dense0;
+    input_port            output_matrixA_rtp;
+
+    NeuralNetworkGraph() {
+        std::string base_path = DATA_DIR;
+
+        // Create top level PLIO
+        pipeline_in = input_plio::create("aieml9_in", plio_32_bits,
+                                         (base_path + "/" + EMBED_INPUT_DATA).c_str());
+        pipeline_out = output_plio::create("aieml9_out", plio_32_bits,
+                                           (base_path + "/" + AIEML9_OUTPUT_FILE).c_str());
+
+        // ------------------------- Stage 1 ---------------------------------
+        connect<parameter>(embed_matrixA_rtp, embed_dense0.matrixA[0]);
+        connect<>(pipeline_in.out[0], embed_dense0.inB[0]);
+
+        embed_bias0 = kernel::create(bias_add_kernel);
+        source(embed_bias0)  = "bias_add.cpp";
+        headers(embed_bias0) = {"bias_add.h"};
+        runtime<ratio>(embed_bias0) = 1.0;
+
+        embed_bias1 = kernel::create(bias_add_kernel);
+        source(embed_bias1)  = "bias_add.cpp";
+        headers(embed_bias1) = {"bias_add.h"};
+        runtime<ratio>(embed_bias1) = 1.0;
+
+        embed_relu0 = kernel::create(leaky_relu_kernel);
+        source(embed_relu0)  = "leaky_relu.cpp";
+        headers(embed_relu0) = {"leaky_relu.h"};
+        runtime<ratio>(embed_relu0) = 1.0;
+
+        embed_relu1 = kernel::create(leaky_relu_kernel);
+        source(embed_relu1)  = "leaky_relu.cpp";
+        headers(embed_relu1) = {"leaky_relu.h"};
+        runtime<ratio>(embed_relu1) = 1.0;
+
+        embed_split0 = kernel::create(window_split_128_to_64x2);
+        source(embed_split0)  = "window_split_128_to_64x2.cpp";
+        headers(embed_split0) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(embed_split0) = 1.0;
+
+        connect<window<512>>(embed_dense0.out[0], embed_bias0.in[0]);
+        connect<parameter>(embed_bias0_rtp, embed_bias0.in[1]);
+        connect<window<512>>(embed_bias0.out[0], embed_relu0.in[0]);
+        connect<window<512>>(embed_relu0.out[0], embed_split0.in[0]);
+
+        auto embed_split_leg0 = connect<window<256>>(embed_split0.out[0], embed_dense1.inB[0]);
+        auto embed_split_leg1 = connect<window<256>>(embed_split0.out[1], embed_dense1.inB[1]);
+        adf::fifo_depth(embed_split_leg0) = 8;
+        adf::fifo_depth(embed_split_leg1) = 8;
+
+        for (int i = 0; i < TP_CASC_LEN_STAGE1_LAYER1; ++i) {
+            connect<parameter>(embed_matrixA1_rtp[i], embed_dense1.matrixA[i]);
+        }
+
+        connect<window<512>>(embed_dense1.out[0], embed_bias1.in[0]);
+        connect<parameter>(embed_bias1_rtp, embed_bias1.in[1]);
+        connect<window<512>>(embed_bias1.out[0], embed_relu1.in[0]);
+
+        // ------------------------- Stage 2 ---------------------------------
+        solver_rollconcat = kernel::create(roll_concat_kernel);
+        source(solver_rollconcat)  = "roll_concat.cpp";
+        headers(solver_rollconcat) = {"roll_concat.h"};
+        runtime<ratio>(solver_rollconcat) = 1.0;
+
+        connect<window<512>>(embed_relu1.out[0], solver_rollconcat.in[0]);
+        dimensions(solver_rollconcat.in[0])  = {HIDDEN_SIZE};
+        dimensions(solver_rollconcat.out[0]) = {ROLL_CONCAT_TOTAL};
+        dimensions(solver_rollconcat.out[1]) = {ROLL_CONCAT_TOTAL};
+
+        solver_roll_buf_a = shared_buffer<float>::create({ROLL_CONCAT_TOTAL}, 1, TP_CASC_PER_BUFFER);
+        solver_roll_buf_b = shared_buffer<float>::create({ROLL_CONCAT_TOTAL}, 1, TP_CASC_PER_BUFFER);
+
+        connect<>(solver_rollconcat.out[0], solver_roll_buf_a.in[0]);
+        connect<>(solver_rollconcat.out[1], solver_roll_buf_b.in[0]);
+
+        write_access(solver_roll_buf_a.in[0]) = tiling({
+            .buffer_dimension = {ROLL_CONCAT_TOTAL},
+            .tiling_dimension = {ROLL_CONCAT_TOTAL},
+            .offset = {0}
+        });
+        write_access(solver_roll_buf_b.in[0]) = tiling({
+            .buffer_dimension = {ROLL_CONCAT_TOTAL},
+            .tiling_dimension = {ROLL_CONCAT_TOTAL},
+            .offset = {0}
+        });
+
+        for (int i = 0; i < TP_CASC_PER_BUFFER; ++i) {
+            connect<>(solver_roll_buf_a.out[i], solver_dense0.inB[i]);
+            read_access(solver_roll_buf_a.out[i]) = tiling({
+                .buffer_dimension = {ROLL_CONCAT_TOTAL},
+                .tiling_dimension = {ROLL_CONCAT_TILE_SPAN},
+                .offset = {static_cast<int>(i * ROLL_CONCAT_TILE_SPAN)}
+            });
+        }
+        for (int i = 0; i < TP_CASC_PER_BUFFER; ++i) {
+            const int cascade_index = TP_CASC_PER_BUFFER + i;
+            connect<>(solver_roll_buf_b.out[i], solver_dense0.inB[cascade_index]);
+            read_access(solver_roll_buf_b.out[i]) = tiling({
+                .buffer_dimension = {ROLL_CONCAT_TOTAL},
+                .tiling_dimension = {ROLL_CONCAT_TILE_SPAN},
+                .offset = {static_cast<int>(cascade_index * ROLL_CONCAT_TILE_SPAN)}
+            });
+        }
+
+        auto connect_layer_weights = [&](auto& plios,
+                                         const char* name_prefix,
+                                         const char* file_prefix) {
+            for (int part = 0; part < static_cast<int>(plios.size()); ++part) {
+                const std::string plio_name = std::string(name_prefix) + std::to_string(part);
+                const std::string file_path = base_path + "/" + file_prefix + std::to_string(part) + ".txt";
+                plios[part] = input_plio::create(plio_name.c_str(), plio_32_bits, file_path.c_str());
+            }
+        };
+
+        for (int part = 0; part < SUBSOLVER0_INPUT_PARTS; ++part) {
+            const std::string plio_name = "solver_dense0_w_part" + std::to_string(part);
+            const std::string file_path = base_path + "/" + SUBSOLVER0_DENSE0_WEIGHTS_PREFIX + std::to_string(part) + ".txt";
+            solver_dense0_weight_plios[part] = input_plio::create(plio_name.c_str(), plio_32_bits, file_path.c_str());
+            connect<>(solver_dense0_weight_plios[part].out[0], solver_dense0.inA[part]);
+        }
+
+        connect_layer_weights(solver_dense1_weight_plios, "solver_dense1_w_part", SUBSOLVER0_DENSE1_WEIGHTS_PREFIX);
+        connect_layer_weights(solver_dense2_weight_plios, "solver_dense2_w_part", SUBSOLVER0_DENSE2_WEIGHTS_PREFIX);
+        connect_layer_weights(solver_dense3_weight_plios, "solver_dense3_w_part", SUBSOLVER0_DENSE3_WEIGHTS_PREFIX);
+
+        connect<>(solver_dense1_weight_plios[0].out[0], solver_dense1.inA[0]);
+        connect<>(solver_dense1_weight_plios[1].out[0], solver_dense1.inA[1]);
+        connect<>(solver_dense2_weight_plios[0].out[0], solver_dense2.inA[0]);
+        connect<>(solver_dense2_weight_plios[1].out[0], solver_dense2.inA[1]);
+        connect<>(solver_dense3_weight_plios[0].out[0], solver_dense3.inA[0]);
+        connect<>(solver_dense3_weight_plios[1].out[0], solver_dense3.inA[1]);
+
+        solver_bias0 = kernel::create(bias_add_kernel);
+        source(solver_bias0)  = "bias_add.cpp";
+        headers(solver_bias0) = {"bias_add.h"};
+        runtime<ratio>(solver_bias0) = 0.45;
+
+        solver_bias1 = kernel::create(bias_add_kernel);
+        source(solver_bias1)  = "bias_add.cpp";
+        headers(solver_bias1) = {"bias_add.h"};
+        runtime<ratio>(solver_bias1) = 0.45;
+
+        solver_bias2 = kernel::create(bias_add_kernel);
+        source(solver_bias2)  = "bias_add.cpp";
+        headers(solver_bias2) = {"bias_add.h"};
+        runtime<ratio>(solver_bias2) = 0.45;
+
+        solver_bias3 = kernel::create(bias_add_kernel);
+        source(solver_bias3)  = "bias_add.cpp";
+        headers(solver_bias3) = {"bias_add.h"};
+        runtime<ratio>(solver_bias3) = 0.45;
+
+        solver_relu0 = kernel::create(leaky_relu_kernel);
+        source(solver_relu0)  = "leaky_relu.cpp";
+        headers(solver_relu0) = {"leaky_relu.h"};
+        runtime<ratio>(solver_relu0) = 0.5;
+
+        solver_relu1 = kernel::create(leaky_relu_kernel);
+        source(solver_relu1)  = "leaky_relu.cpp";
+        headers(solver_relu1) = {"leaky_relu.h"};
+        runtime<ratio>(solver_relu1) = 0.5;
+
+        solver_relu2 = kernel::create(leaky_relu_kernel);
+        source(solver_relu2)  = "leaky_relu.cpp";
+        headers(solver_relu2) = {"leaky_relu.h"};
+        runtime<ratio>(solver_relu2) = 0.5;
+
+        solver_relu3 = kernel::create(leaky_relu_kernel);
+        source(solver_relu3)  = "leaky_relu.cpp";
+        headers(solver_relu3) = {"leaky_relu.h"};
+        runtime<ratio>(solver_relu3) = 0.5;
+
+        solver_split0 = kernel::create(window_split_128_to_64x2);
+        source(solver_split0)  = "window_split_128_to_64x2.cpp";
+        headers(solver_split0) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(solver_split0) = 0.65;
+
+        solver_split1 = kernel::create(window_split_128_to_64x2);
+        source(solver_split1)  = "window_split_128_to_64x2.cpp";
+        headers(solver_split1) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(solver_split1) = 0.65;
+
+        solver_split2 = kernel::create(window_split_128_to_64x2);
+        source(solver_split2)  = "window_split_128_to_64x2.cpp";
+        headers(solver_split2) = {"window_split_128_to_64x2.h"};
+        runtime<ratio>(solver_split2) = 0.65;
+
+        connect<window<512>>(solver_dense0.out[0], solver_bias0.in[0]);
+        connect<parameter>(solver_bias0_rtp, solver_bias0.in[1]);
+        connect<window<512>>(solver_bias0.out[0], solver_relu0.in[0]);
+        connect<window<512>>(solver_relu0.out[0], solver_split0.in[0]);
+
+        auto solver_split0_leg0 = connect<window<256>>(solver_split0.out[0], solver_dense1.inB[0]);
+        auto solver_split0_leg1 = connect<window<256>>(solver_split0.out[1], solver_dense1.inB[1]);
+        adf::fifo_depth(solver_split0_leg0) = 8;
+        adf::fifo_depth(solver_split0_leg1) = 8;
+
+        connect<window<512>>(solver_dense1.out[0], solver_bias1.in[0]);
+        connect<parameter>(solver_bias1_rtp, solver_bias1.in[1]);
+        connect<window<512>>(solver_bias1.out[0], solver_relu1.in[0]);
+        connect<window<512>>(solver_relu1.out[0], solver_split1.in[0]);
+
+        auto solver_split1_leg0 = connect<window<256>>(solver_split1.out[0], solver_dense2.inB[0]);
+        auto solver_split1_leg1 = connect<window<256>>(solver_split1.out[1], solver_dense2.inB[1]);
+        adf::fifo_depth(solver_split1_leg0) = 8;
+        adf::fifo_depth(solver_split1_leg1) = 8;
+
+        connect<window<512>>(solver_dense2.out[0], solver_bias2.in[0]);
+        connect<parameter>(solver_bias2_rtp, solver_bias2.in[1]);
+        connect<window<512>>(solver_bias2.out[0], solver_relu2.in[0]);
+        connect<window<512>>(solver_relu2.out[0], solver_split2.in[0]);
+
+        auto solver_split2_leg0 = connect<window<256>>(solver_split2.out[0], solver_dense3.inB[0]);
+        auto solver_split2_leg1 = connect<window<256>>(solver_split2.out[1], solver_dense3.inB[1]);
+        adf::fifo_depth(solver_split2_leg0) = 8;
+        adf::fifo_depth(solver_split2_leg1) = 8;
+
+        connect<window<512>>(solver_dense3.out[0], solver_bias3.in[0]);
+        connect<parameter>(solver_bias3_rtp, solver_bias3.in[1]);
+        connect<window<512>>(solver_bias3.out[0], solver_relu3.in[0]);
+
+        // ------------------------- Stage 3 ---------------------------------
+        connect<parameter>(output_matrixA_rtp, output_dense0.matrixA[0]);
+
+        auto solver_to_output = connect<window<512>>(solver_relu3.out[0], output_dense0.inB[0]);
+        adf::fifo_depth(solver_to_output) = 8;
+
+        connect<window<128>>(output_dense0.out[0], pipeline_out.in[0]);
+    }
+};

--- a/aieml9/leaky_relu.cpp
+++ b/aieml9/leaky_relu.cpp
@@ -1,0 +1,17 @@
+#include "leaky_relu.h"
+#include <aie_api/aie.hpp>
+
+using namespace adf;
+
+void leaky_relu_kernel(input_window<float>* __restrict in,
+                       output_window<float>* __restrict out) {
+  constexpr float alpha      = 0.1f;
+  constexpr int   frame_size = 128;
+
+  // process one window of HIDDEN_SIZE elements
+  for (int i = 0; i < frame_size; ++i) {
+    float x = window_readincr(in);
+    float y = (x >= 0.0f) ? x : (alpha * x);
+    window_writeincr(out, y);
+  }
+}

--- a/aieml9/leaky_relu.h
+++ b/aieml9/leaky_relu.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+using namespace adf;
+
+// void leaky_relu_kernel(input_stream<float>* __restrict in,
+//                        output_stream<float>* __restrict out);
+
+void leaky_relu_kernel(input_window<float>* __restrict in,
+                        output_window<float>* __restrict out);

--- a/aieml9/roll_concat.cpp
+++ b/aieml9/roll_concat.cpp
@@ -1,0 +1,30 @@
+#include "roll_concat.h"
+#include <aie_api/aie.hpp>
+
+using namespace adf;
+
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out0,
+                        adf::output_buffer<float>& __restrict out1) {
+  constexpr int N = HIDDEN_SIZE;
+  constexpr int K = ROLL_CONC_SUBSET_SIZE;
+
+  // Read one input window (N floats) into a local buffer
+  float buf[N];
+  auto inIt = aie::begin(in);
+  for (int i = 0; i < N; ++i) {
+    buf[i] = *inIt++;
+  }
+
+  // Write K rolled views back-to-back as a single output buffer of size N*K
+  auto outIt0 = aie::begin(out0);
+  auto outIt1 = aie::begin(out1);
+  for (int shift = 0; shift < K; ++shift) {
+    for (int i = 0; i < N; ++i) {
+      const int idx = (i + shift) % N;
+      const float value = buf[idx];
+      *outIt0++ = value;
+      *outIt1++ = value;
+    }
+  }
+}

--- a/aieml9/roll_concat.h
+++ b/aieml9/roll_concat.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <adf.h>
+#include "nn_defs.h"
+
+using namespace adf;
+
+// Reads one buffer of HIDDEN_SIZE floats and emits
+// ROLL_CONC_SUBSET_SIZE consecutive rolled windows (flattened as one buffer)
+// on two output buffers so that multiple shared buffers can consume the
+// generated tiles.
+void roll_concat_kernel(adf::input_buffer<float>& __restrict in,
+                        adf::output_buffer<float>& __restrict out0,
+                        adf::output_buffer<float>& __restrict out1);

--- a/aieml9/window_split_128_to_64x2.cpp
+++ b/aieml9/window_split_128_to_64x2.cpp
@@ -1,0 +1,16 @@
+#include "window_split_128_to_64x2.h"
+
+void window_split_128_to_64x2(input_window<float>* __restrict in,
+                              output_window<float>* __restrict out0,
+                              output_window<float>* __restrict out1) {
+  constexpr int N  = 128;
+  constexpr int H  = 64;
+
+  // First 64 → out0
+  for (int i = 0; i < H; ++i)
+    window_writeincr(out0, window_readincr(in));
+
+  // Second 64 → out1
+  for (int i = 0; i < H; ++i)
+    window_writeincr(out1, window_readincr(in));
+}

--- a/aieml9/window_split_128_to_64x2.h
+++ b/aieml9/window_split_128_to_64x2.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <adf.h>
+using namespace adf;
+
+void window_split_128_to_64x2(input_window<float>* __restrict in,
+                              output_window<float>* __restrict out0,
+                              output_window<float>* __restrict out1);

--- a/common/data_paths.h
+++ b/common/data_paths.h
@@ -47,6 +47,7 @@
 #define OUTPUT_DENSE0_OUTPUT        "output_dense_0_output_aie.txt"
 #define OUTPUT_DENSE0_BIAS          "output_dense_0_bias.txt"
 #define OUTPUT_HOST_OUTPUT          "output_host_output.txt"
+#define AIEML9_OUTPUT_FILE          "aieml9_output_aie.txt"
 
 // Miscellaneous -----------------------------------------------------------
 #define EMBED_HOST_OUTPUT           "host_output.txt"


### PR DESCRIPTION
## Summary
- add a new aieml9 graph that composes the aieml6, aieml7, and aieml8 stages into a single AI Engine pipeline with FIFO depth tuning
- provide runtime weight/bias loading for the combined design and route the final output to a dedicated data file
- supply build collateral (Makefile, README, configuration, and kernels) for compiling and simulating the merged design

## Testing
- make -C aieml9 graph *(fails: `v++` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e420a5386c8320997bc0086039890b